### PR TITLE
Builds sample/site location table csv and READMEs

### DIFF
--- a/content/tables/per_sample_location_table.csv
+++ b/content/tables/per_sample_location_table.csv
@@ -1,0 +1,2785 @@
+sample_id,partner_sample_id,sample_set,country,site,year,month,latitude,longitude,sex_call,aim_fraction_colu,aim_fraction_arab,species_gambcolu_arabiensis,species_gambiae_coluzzii,is_arabiensis,is_gamb_colu,is_gambiae,is_coluzzii
+AR0047-C,LUA047,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.945,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0049-C,LUA049,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.933,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0051-C,LUA051,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.937,0.002,gamb_colu,coluzzii,False,True,False,True
+AR0061-C,LUA061,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.938,0.002,gamb_colu,coluzzii,False,True,False,True
+AR0078-C,LUA078,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.926,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0080-C,LUA080,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.941,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0084-C,LUA084,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.949,0.002,gamb_colu,coluzzii,False,True,False,True
+AR0097-C,LUA097,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.936,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0072-C,LUA072,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.944,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0094-C,LUA094,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,M,0.946,0.002,gamb_colu,coluzzii,False,True,False,True
+AR0095-C,LUA095,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.927,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0083-C,LUA083,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.94,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0093-C,LUA093,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.944,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0021-C,LUA021,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.937,0.002,gamb_colu,coluzzii,False,True,False,True
+AR0082-C,LUA082,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.944,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0008-C,LUA008,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.944,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0085-C,LUA085,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.936,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0098-C,LUA098,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.938,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0092-C,LUA092,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.933,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0017-C,LUA017,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.944,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0015-C,LUA015,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.932,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0019-C,LUA019,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.94,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0100-C,LUA100,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.937,0.002,gamb_colu,coluzzii,False,True,False,True
+AR0034-C,LUA034,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.941,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0086-C,LUA086,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.921,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0057-C,LUA057,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.931,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0076-C,LUA076,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.94,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0042-C,LUA042,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.944,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0063-C,LUA063,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.931,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0012-C,LUA012,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.946,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0087-C,LUA087,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.944,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0065-C,LUA065,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.945,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0038-C,LUA038,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.935,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0089-C,LUA089,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.928,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0071-C,LUA071,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.939,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0096-C,LUA096,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.935,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0088-C,LUA088,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.936,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0066-C,LUA066,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.942,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0023-C,LUA023,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.926,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0020-C,LUA020,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.942,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0024-C,LUA024,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.944,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0014-C,LUA014,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.926,0.002,gamb_colu,coluzzii,False,True,False,True
+AR0079-C,LUA079,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.941,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0027-C,LUA027,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.944,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0075-C,LUA075,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.942,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0077-C,LUA077,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.949,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0007-C,LUA007,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.94,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0062-C,LUA062,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.928,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0060-C,LUA060,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.939,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0022-C,LUA022,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.938,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0002-C,LUA002,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,M,0.939,0.002,gamb_colu,coluzzii,False,True,False,True
+AR0059-C,LUA059,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.936,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0048-C,LUA048,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.939,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0011-C,LUA011,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.936,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0009-C,LUA009,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.952,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0043-C,LUA043,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.932,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0035-C,LUA035,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.934,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0074-C,LUA074,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.942,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0045-C,LUA045,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.93,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0073-C,LUA073,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.937,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0004-C,LUA004,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,M,0.936,0.002,gamb_colu,coluzzii,False,True,False,True
+AR0040-C,LUA040,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.942,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0052-C,LUA052,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.938,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0064-C,LUA064,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.933,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0044-C,LUA044,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.935,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0036-C,LUA036,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.939,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0001-C,LUA001,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.945,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0006-C,LUA006,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,M,0.938,0.002,gamb_colu,coluzzii,False,True,False,True
+AR0046-C,LUA046,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.927,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0070-Cx,LUA070,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.924,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0010-Cx,LUA010,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.937,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0090-Cx,LUA090,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.937,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0054-Cx,LUA054,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.944,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0016-Cx,LUA016,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.943,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0050-Cx,LUA050,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.933,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0069-Cx,LUA069,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.936,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0018-Cx,LUA018,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.938,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0081-Cx,LUA081,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.929,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0013-Cx,LUA013,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.945,0.001,gamb_colu,coluzzii,False,True,False,True
+AR0026-C,LUA026,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.942,0.002,gamb_colu,coluzzii,False,True,False,True
+AR0053-C,LUA053,AG1000G-AO,Angola,Luanda,2009,4,-8.884,13.302,F,0.944,0.001,gamb_colu,coluzzii,False,True,False,True
+AB0085-Cx,BF2-4,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AB0086-Cx,BF2-6,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.038,0.002,gamb_colu,gambiae,False,True,True,False
+AB0087-C,BF3-3,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.982,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0088-C,BF3-5,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.99,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0089-Cx,BF3-8,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.975,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0090-C,BF3-10,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.977,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0091-C,BF3-12,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.974,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0092-C,BF3-13,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.978,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0094-Cx,BF3-17,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.986,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0095-Cx,BF4-1,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.977,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0096-C,BF4-4,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.032,0.002,gamb_colu,gambiae,False,True,True,False
+AB0097-Cx,BF4-5,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.961,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0098-Cx,BF4-6,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.971,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0099-Cx,BF6-1,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.988,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0100-C,BF6-2,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.975,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0101-C,BF6-3,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.984,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0103-C,BF6-7,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.04,0.002,gamb_colu,gambiae,False,True,True,False
+AB0104-Cx,BF6-8,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AB0109-C,BF9-1,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.974,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0110-C,BF9-2,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.974,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0111-C,BF9-3,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.983,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0112-C,BF3-18,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.978,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0113-C,BF3-19,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.979,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0114-C,BF4-7,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.983,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0115-C,BF4-8,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.979,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0116-C,BF4-10,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.045,0.002,gamb_colu,gambiae,False,True,True,False
+AB0117-C,BF3-21,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,M,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AB0118-C,BF3-22,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,M,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AB0119-C,BF3-23,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,M,0.055,0.002,gamb_colu,gambiae,False,True,True,False
+AB0121-C,BF3-25,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,M,0.912,0.003,gamb_colu,coluzzii,False,True,False,True
+AB0122-C,BF3-26,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,M,0.979,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0123-C,BF3-27,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,M,0.967,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0124-C,BF3-28,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,M,0.973,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0126-Cx,BF3-30,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,M,0.025,0.003,gamb_colu,gambiae,False,True,True,False
+AB0127-C,BF3-31,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,M,0.027,0.003,gamb_colu,gambiae,False,True,True,False
+AB0128-C,BF3-32,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,M,0.054,0.003,gamb_colu,gambiae,False,True,True,False
+AB0129-C,BF3-33,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,M,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AB0130-Cx,BF3-34,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,M,0.025,0.003,gamb_colu,gambiae,False,True,True,False
+AB0131-Cx,BF3-35,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,M,0.157,0.002,gamb_colu,intermediate,False,True,False,False
+AB0132-C,BF2-13,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.98,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0133-C,BF2-14,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.067,0.002,gamb_colu,gambiae,False,True,True,False
+AB0134-C,BF2-15,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.017,0.002,gamb_colu,gambiae,False,True,True,False
+AB0135-C,BF2-16,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.063,0.002,gamb_colu,gambiae,False,True,True,False
+AB0136-Cx,BF2-17,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AB0137-Cx,BF2-18,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.982,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0138-Cx,BF2-19,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.987,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0139-C,BF2-20,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.971,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0140-C,BF2-21,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.965,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0142-C,BF2-23,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.984,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0143-Cx,BF8-1,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.027,0.003,gamb_colu,gambiae,False,True,True,False
+AB0144-C,BF8-2,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AB0145-C,BF8-3,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AB0146-Cx,BF8-5,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.03,0.002,gamb_colu,gambiae,False,True,True,False
+AB0147-C,BF8-6,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AB0148-Cx,BF8-7,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AB0150-Cx,BF3-37,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,M,0.022,0.003,gamb_colu,gambiae,False,True,True,False
+AB0151-Cx,BF3-38,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,M,0.026,0.003,gamb_colu,gambiae,False,True,True,False
+AB0153-C,BF3-40,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,M,0.065,0.002,gamb_colu,gambiae,False,True,True,False
+AB0155-Cx,BF3-42,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,M,0.033,0.003,gamb_colu,gambiae,False,True,True,False
+AB0157-Cx,BF3-44,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,M,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AB0158-Cx,BF3-45,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,M,0.083,0.002,gamb_colu,gambiae,False,True,True,False
+AB0159-C,BF3-46,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,M,0.034,0.003,gamb_colu,gambiae,False,True,True,False
+AB0160-Cx,BF3-47,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,M,0.032,0.003,gamb_colu,gambiae,False,True,True,False
+AB0161-C,BF3-48,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,M,0.029,0.003,gamb_colu,gambiae,False,True,True,False
+AB0162-C,BF3-54,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,M,0.033,0.002,gamb_colu,gambiae,False,True,True,False
+AB0164-C,BF3-56,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,M,0.027,0.003,gamb_colu,gambiae,False,True,True,False
+AB0165-C,BF3-59,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,M,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AB0166-C,BF3-60,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,M,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AB0167-C,BF3-61,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,M,0.026,0.003,gamb_colu,gambiae,False,True,True,False
+AB0169-C,BF3-64,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,M,0.02,0.003,gamb_colu,gambiae,False,True,True,False
+AB0170-C,BF3-65,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,M,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AB0171-Cx,BF3-66,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,M,0.026,0.003,gamb_colu,gambiae,False,True,True,False
+AB0172-Cx,BF10-1,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AB0173-C,BF10-2,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.025,0.003,gamb_colu,gambiae,False,True,True,False
+AB0174-C,BF10-3,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AB0175-Cx,BF10-4,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.03,0.002,gamb_colu,gambiae,False,True,True,False
+AB0176-Cx,BF10-5,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+AB0177-C,BF10-7,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.025,0.003,gamb_colu,gambiae,False,True,True,False
+AB0178-C,BF10-8,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AB0179-Cx,BF10-9,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AB0180-Cx,BF10-10,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.045,0.002,gamb_colu,gambiae,False,True,True,False
+AB0181-C,BFBana 4.2,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.982,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0182-C,BFBana 4.3,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.974,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0183-C,BFBana5.1,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.969,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0184-C,BFBana 5.2,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.977,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0185-Cx,BFBana 6.1,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.974,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0186-C,BFBana 6.2,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.979,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0187-C,BFBana 7.1,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.973,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0188-C,BFBana 7.2,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.977,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0189-C,BFBana 8.1,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.975,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0190-C,BFBana 8.2,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.976,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0191-Cx,BFBana 17.2,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.953,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0192-C,BFBana 17.3,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.986,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0193-C,BFBana 18.1,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.983,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0194-C,BFBana 18.2,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.983,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0196-C,BFBana 19.2,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.98,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0197-C,BFPala 36.1,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AB0198-C,BFPala 36.2,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.015,0.002,gamb_colu,gambiae,False,True,True,False
+AB0199-C,BFPala 36.3,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AB0200-C,BFPala 36.4,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.031,0.002,gamb_colu,gambiae,False,True,True,False
+AB0201-Cx,BFPala 48.1,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.028,0.002,gamb_colu,gambiae,False,True,True,False
+AB0202-Cx,BFPala 48.2,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AB0203-C,BFPala 48.3,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.02,0.002,gamb_colu,gambiae,False,True,True,False
+AB0204-C,BFPala 58.1,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.979,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0205-C,BFPala 58.2,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.063,0.002,gamb_colu,gambiae,False,True,True,False
+AB0206-C,BFPala 58.3,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AB0207-C,BFSour 59.1,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.032,0.002,gamb_colu,gambiae,False,True,True,False
+AB0208-C,BFSour 59.2,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.043,0.002,gamb_colu,gambiae,False,True,True,False
+AB0209-C,BFBana 14.1,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.979,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0210-C,BFBana 14.2,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.978,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0211-C,BFBana 16.1,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AB0212-C,BFBana 16.2,AG1000G-BF-A,Burkina Faso,Bana,2012,7,11.233,-4.472,F,0.984,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0213-C,BFSour 59.3,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.976,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0214-C,BFSour 46.1,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.975,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0215-C,BFSour 46.2,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.981,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0216-C,BFSour 47.1,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.965,0.023,gamb_colu,coluzzii,False,True,False,True
+AB0217-C,BFSour 54.1,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.033,0.002,gamb_colu,gambiae,False,True,True,False
+AB0218-C,BFSour 54.2,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.02,0.003,gamb_colu,gambiae,False,True,True,False
+AB0219-Cx,BFSour 54.3,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.985,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0221-C,BFSour 55.2,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.975,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0222-C,BFSour 55.3,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.964,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0223-C,BFSour 56.1,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.981,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0224-C,BFSour 57.1,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.975,0.003,gamb_colu,coluzzii,False,True,False,True
+AB0225-C,BFSour 57.2,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AB0226-C,BFSour 57.3,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.985,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0227-Cx,BF11-2,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.984,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0228-C,BF11-3,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.031,0.002,gamb_colu,gambiae,False,True,True,False
+AB0229-C,BF11-4,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.984,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0230-Cx,BF11-6,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.977,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0231-C,BF11-7,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.028,0.002,gamb_colu,gambiae,False,True,True,False
+AB0232-Cx,BF11-8,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.019,0.002,gamb_colu,gambiae,False,True,True,False
+AB0233-C,BF11-9,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.015,0.002,gamb_colu,gambiae,False,True,True,False
+AB0234-C,BF11-10,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.978,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0235-C,BF11-11,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.03,0.002,gamb_colu,gambiae,False,True,True,False
+AB0236-Cx,BF11-12,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AB0237-C,BF11-13,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.979,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0238-C,BF11-14,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AB0239-C,BF11-15,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.036,0.002,gamb_colu,gambiae,False,True,True,False
+AB0240-C,BF11-16,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.982,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0241-C,BF11-17,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AB0242-C,BF11-18,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.982,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0243-C,BF11-19,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.974,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0244-C,BF11-20,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.02,0.002,gamb_colu,gambiae,False,True,True,False
+AB0246-C,BF11-22,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.983,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0247-C,BF11-23,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.961,0.003,gamb_colu,coluzzii,False,True,False,True
+AB0248-C,BF11-25,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.98,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0249-Cx,BF11-26,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.978,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0250-Cx,BF11-27,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.968,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0251-C,BF11-28,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AB0252-C,BF11-29,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.012,0.002,gamb_colu,gambiae,False,True,True,False
+AB0253-C,BF11-30,AG1000G-BF-A,Burkina Faso,Souroukoudinga,2012,7,11.235,-4.535,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AB0255-C,BF12-2,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AB0256-C,BF12-3,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.036,0.002,gamb_colu,gambiae,False,True,True,False
+AB0257-C,BF12-4,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.986,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0258-Cx,BF12-5,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.973,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0259-Cx,BF12-6,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.977,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0260-C,BF12-7,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AB0261-Cx,BF12-8,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.01,0.002,gamb_colu,gambiae,False,True,True,False
+AB0262-Cx,BF12-9,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.977,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0263-C,BF12-10,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.986,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0264-C,BF12-13,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.016,0.002,gamb_colu,gambiae,False,True,True,False
+AB0265-C,BF12-14,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.014,0.002,gamb_colu,gambiae,False,True,True,False
+AB0266-Cx,BF12-15,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.983,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0267-C,BF12-16,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.987,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0268-C,BF12-17,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AB0269-Cx,BF12-18,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AB0270-C,BF12-20,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AB0271-Cx,BF12-22,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AB0272-Cx,BF12-23,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.015,0.002,gamb_colu,gambiae,False,True,True,False
+AB0273-Cx,BF12-24,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AB0274-C,BF12-25,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AB0275-C,BF12-26,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+AB0276-C,BF12-27,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.973,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0277-C,BF12-28,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.065,0.002,gamb_colu,gambiae,False,True,True,False
+AB0278-C,BF12-29,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.017,0.002,gamb_colu,gambiae,False,True,True,False
+AB0279-C,BF12-30,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.983,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0280-Cx,BF12-31,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.065,0.003,gamb_colu,gambiae,False,True,True,False
+AB0281-Cx,BF12-32,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AB0282-Cx,BF12-33,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.975,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0283-C,BF10-12,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.028,0.002,gamb_colu,gambiae,False,True,True,False
+AB0284-C,BF10-13,AG1000G-BF-A,Burkina Faso,Pala,2012,7,11.15,-4.235,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AB0326-C,BF18-1,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,F,0.971,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0327-C,BF18-3,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,F,0.989,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0328-C,BF18-4,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,F,0.983,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0329-C,BF18-5,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,F,0.97,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0330-C,BF18-6,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,F,0.967,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0331-C,BF18-9,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,F,0.979,0.003,gamb_colu,coluzzii,False,True,False,True
+AB0332-C,BF18-10,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,F,0.977,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0333-C,BF18-11,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,F,0.472,0.731,arabiensis,,True,False,False,False
+AB0334-C,BF18-12,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,F,0.975,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0337-C,BF22-15,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,F,0.989,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0338-C,BF18-13,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,F,0.978,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0339-C,BF18-14,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,F,0.977,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0340-C,BF18-15,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,F,0.975,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0341-C,BF18-16,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,F,0.975,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0348-C,BF22-50,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,F,0.973,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0351-C,BF23-6,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,M,0.964,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0352-C,BF18-46,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,M,0.977,0.003,gamb_colu,coluzzii,False,True,False,True
+AB0354-C,BF18-21,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,M,0.983,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0355-C,BF18-22,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,M,0.975,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0356-C,BF18-23,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,M,0.973,0.003,gamb_colu,coluzzii,False,True,False,True
+AB0357-C,BF18-24,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,M,0.982,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0358-C,BF18-25,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,M,0.987,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0359-C,BF18-26,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,M,0.972,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0360-C,BF18-28,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,M,0.982,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0361-C,BF18-29,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,M,0.983,0.003,gamb_colu,coluzzii,False,True,False,True
+AB0362-C,BF18-31,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,M,0.982,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0363-C,BF18-32,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,M,0.975,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0364-C,BF18-33,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,M,0.978,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0365-C,BF18-34,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,M,0.976,0.003,gamb_colu,coluzzii,False,True,False,True
+AB0366-C,BF18-35,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,M,0.972,0.003,gamb_colu,coluzzii,False,True,False,True
+AB0367-C,BF18-36,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,M,0.981,0.003,gamb_colu,coluzzii,False,True,False,True
+AB0368-C,BF18-37,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,M,0.986,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0369-C,BF18-38,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,M,0.976,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0370-C,BF18-42,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,M,0.964,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0371-C,BF18-44,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,M,0.973,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0372-C,BF18-45,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,M,0.957,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0373-C,BF18-2,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,F,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+AB0374-C,BF18-7,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,F,0.016,0.002,gamb_colu,gambiae,False,True,True,False
+AB0375-C,BF18-8,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AB0378-C,BF22-57,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AB0379-C,BF22-59,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,F,0.03,0.002,gamb_colu,gambiae,False,True,True,False
+AB0381-C,BF18-18,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,M,0.045,0.003,gamb_colu,gambiae,False,True,True,False
+AB0386-C,BF18-39,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,M,0.035,0.003,gamb_colu,gambiae,False,True,True,False
+AB0388-C,BF18-41,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,M,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AB0389-C,BF18-43,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,M,0.027,0.003,gamb_colu,gambiae,False,True,True,False
+AB0396-C,BF14-8,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,F,0.985,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0397-C,BF14-9,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,F,0.984,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0398-C,BF14-10,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,F,0.989,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0399-C,BF14-11,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,F,0.989,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0400-C,BF14-12,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,F,0.972,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0403-C,BF14-16,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,F,0.99,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0404-C,BF14-18,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,F,0.978,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0409-C,BF14-21,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,F,0.968,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0410-C,BF20-54,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,F,0.973,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0411-C,BF20-56,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,F,0.983,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0413-C,BF20-59,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,F,0.971,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0432-C,BF14-3,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,F,0.023,0.003,gamb_colu,gambiae,False,True,True,False
+AB0433-C,BF14-4,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,F,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+AB0435-C,BF14-17,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AB0436-C,BF14-19,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,F,0.028,0.003,gamb_colu,gambiae,False,True,True,False
+AB0439-C,BF14-22,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AB0440-C,BF14-23,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,F,0.016,0.002,gamb_colu,gambiae,False,True,True,False
+AB0457-C,BF17-34,AG1000G-BF-B,Burkina Faso,Pala,2014,7,11.15,-4.235,M,0.452,0.712,arabiensis,,True,False,False,False
+AB0458-C,BF16-1,AG1000G-BF-B,Burkina Faso,Pala,2014,7,11.15,-4.235,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AB0459-C,BF16-2,AG1000G-BF-B,Burkina Faso,Pala,2014,7,11.15,-4.235,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AB0460-C,BF16-3,AG1000G-BF-B,Burkina Faso,Pala,2014,7,11.15,-4.235,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AB0462-C,BF16-7,AG1000G-BF-B,Burkina Faso,Pala,2014,7,11.15,-4.235,F,0.019,0.002,gamb_colu,gambiae,False,True,True,False
+AB0463-C,BF17-1,AG1000G-BF-B,Burkina Faso,Pala,2014,7,11.15,-4.235,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AB0465-C,BF17-3,AG1000G-BF-B,Burkina Faso,Pala,2014,7,11.15,-4.235,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AB0466-C,BF17-4,AG1000G-BF-B,Burkina Faso,Pala,2014,7,11.15,-4.235,F,0.022,0.003,gamb_colu,gambiae,False,True,True,False
+AB0467-C,BF17-5,AG1000G-BF-B,Burkina Faso,Pala,2014,7,11.15,-4.235,F,0.019,0.002,gamb_colu,gambiae,False,True,True,False
+AB0468-C,BF17-17,AG1000G-BF-B,Burkina Faso,Pala,2014,7,11.15,-4.235,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AB0469-C,BF17-18,AG1000G-BF-B,Burkina Faso,Pala,2014,7,11.15,-4.235,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AB0470-C,BF17-20,AG1000G-BF-B,Burkina Faso,Pala,2014,7,11.15,-4.235,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AB0471-C,BF17-21,AG1000G-BF-B,Burkina Faso,Pala,2014,7,11.15,-4.235,F,0.025,0.003,gamb_colu,gambiae,False,True,True,False
+AB0472-C,BF17-22,AG1000G-BF-B,Burkina Faso,Pala,2014,7,11.15,-4.235,F,0.035,0.002,gamb_colu,gambiae,False,True,True,False
+AB0473-C,BF17-23,AG1000G-BF-B,Burkina Faso,Pala,2014,7,11.15,-4.235,F,0.02,0.002,gamb_colu,gambiae,False,True,True,False
+AB0474-C,BF17-24,AG1000G-BF-B,Burkina Faso,Pala,2014,7,11.15,-4.235,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AB0477-C,BF26-60,AG1000G-BF-B,Burkina Faso,Pala,2014,7,11.15,-4.235,F,0.064,0.003,gamb_colu,gambiae,False,True,True,False
+AB0502-C,BF17-15,AG1000G-BF-B,Burkina Faso,Pala,2014,7,11.15,-4.235,M,0.441,0.693,arabiensis,,True,False,False,False
+AB0503-C,BF13-1,AG1000G-BF-B,Burkina Faso,Souroukoudinga,2014,7,11.235,-4.535,F,0.982,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0504-C,BF13-6,AG1000G-BF-B,Burkina Faso,Souroukoudinga,2014,7,11.235,-4.535,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AB0505-C,BF13-13,AG1000G-BF-B,Burkina Faso,Souroukoudinga,2014,7,11.235,-4.535,F,0.975,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0508-C,BF13-38,AG1000G-BF-B,Burkina Faso,Souroukoudinga,2014,7,11.235,-4.535,F,0.978,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0509-C,BF24-55,AG1000G-BF-B,Burkina Faso,Souroukoudinga,2014,7,11.235,-4.535,F,0.984,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0510-C,BF24-56,AG1000G-BF-B,Burkina Faso,Souroukoudinga,2014,7,11.235,-4.535,F,0.968,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0517-C,BF13-42,AG1000G-BF-B,Burkina Faso,Souroukoudinga,2014,7,11.235,-4.535,M,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AB0523-C,BF24-26,AG1000G-BF-B,Burkina Faso,Souroukoudinga,2014,7,11.235,-4.535,F,0.968,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0524-C,BF24-27,AG1000G-BF-B,Burkina Faso,Souroukoudinga,2014,7,11.235,-4.535,F,0.029,0.003,gamb_colu,gambiae,False,True,True,False
+AB0525-C,BF24-28,AG1000G-BF-B,Burkina Faso,Souroukoudinga,2014,7,11.235,-4.535,F,0.015,0.002,gamb_colu,gambiae,False,True,True,False
+AB0526-C,BF24-29,AG1000G-BF-B,Burkina Faso,Souroukoudinga,2014,7,11.235,-4.535,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AB0527-C,BF24-30,AG1000G-BF-B,Burkina Faso,Souroukoudinga,2014,7,11.235,-4.535,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AB0528-C,BF13-2,AG1000G-BF-B,Burkina Faso,Souroukoudinga,2014,7,11.235,-4.535,F,0.029,0.003,gamb_colu,gambiae,False,True,True,False
+AB0529-C,BF13-3,AG1000G-BF-B,Burkina Faso,Souroukoudinga,2014,7,11.235,-4.535,F,0.015,0.003,gamb_colu,gambiae,False,True,True,False
+AB0530-C,BF13-4,AG1000G-BF-B,Burkina Faso,Souroukoudinga,2014,7,11.235,-4.535,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AB0531-C,BF13-8,AG1000G-BF-B,Burkina Faso,Souroukoudinga,2014,7,11.235,-4.535,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AB0532-C,BF13-14,AG1000G-BF-B,Burkina Faso,Souroukoudinga,2014,7,11.235,-4.535,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AB0533-C,BF13-18,AG1000G-BF-B,Burkina Faso,Souroukoudinga,2014,7,11.235,-4.535,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AB0536-C,BF13-31,AG1000G-BF-B,Burkina Faso,Souroukoudinga,2014,7,11.235,-4.535,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AB0537-C,BF13-32,AG1000G-BF-B,Burkina Faso,Souroukoudinga,2014,7,11.235,-4.535,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AB0538-C,BF13-33,AG1000G-BF-B,Burkina Faso,Souroukoudinga,2014,7,11.235,-4.535,F,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+AB0408-C,BF14-20,AG1000G-BF-B,Burkina Faso,Bana,2014,7,11.233,-4.472,F,0.986,0.002,gamb_colu,coluzzii,False,True,False,True
+AB0298-C,5038,AG1000G-BF-C,Burkina Faso,Monomtenga,2004,7,12.06,-1.17,F,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+AB0299-C,5057,AG1000G-BF-C,Burkina Faso,Monomtenga,2004,7,12.06,-1.17,F,0.017,0.002,gamb_colu,gambiae,False,True,True,False
+AB0301-C,5089,AG1000G-BF-C,Burkina Faso,Monomtenga,2004,7,12.06,-1.17,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AB0302-C,5091,AG1000G-BF-C,Burkina Faso,Monomtenga,2004,7,12.06,-1.17,F,0.019,0.002,gamb_colu,gambiae,False,True,True,False
+AB0303-C,5098,AG1000G-BF-C,Burkina Faso,Monomtenga,2004,7,12.06,-1.17,F,0.03,0.003,gamb_colu,gambiae,False,True,True,False
+AB0309-C,6712,AG1000G-BF-C,Burkina Faso,Monomtenga,2004,7,12.06,-1.17,F,0.026,0.003,gamb_colu,gambiae,False,True,True,False
+AB0312-C,6729,AG1000G-BF-C,Burkina Faso,Monomtenga,2004,7,12.06,-1.17,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AB0313-C,6755,AG1000G-BF-C,Burkina Faso,Monomtenga,2004,8,12.06,-1.17,F,0.016,0.002,gamb_colu,gambiae,False,True,True,False
+AB0314-C,6775,AG1000G-BF-C,Burkina Faso,Monomtenga,2004,8,12.06,-1.17,F,0.028,0.002,gamb_colu,gambiae,False,True,True,False
+AB0315-C,6777,AG1000G-BF-C,Burkina Faso,Monomtenga,2004,8,12.06,-1.17,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AB0316-C,6779,AG1000G-BF-C,Burkina Faso,Monomtenga,2004,8,12.06,-1.17,F,0.031,0.002,gamb_colu,gambiae,False,True,True,False
+AB0318-C,5072,AG1000G-BF-C,Burkina Faso,Monomtenga,2004,7,12.06,-1.17,F,0.032,0.002,gamb_colu,gambiae,False,True,True,False
+AB0325-C,1403,AG1000G-BF-C,Burkina Faso,Monomtenga,2004,6,12.06,-1.17,F,0.019,0.002,gamb_colu,gambiae,False,True,True,False
+BP0009-C,Gba_1_9,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,M,0.032,0.002,gamb_colu,gambiae,False,True,True,False
+BP0010-C,Gba_1_10,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+BP0011-C,Gba_1_11,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,M,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+BP0012-C,Gba_1_12,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.019,0.002,gamb_colu,gambiae,False,True,True,False
+BP0013-C,Gba_1_13,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,M,0.02,0.002,gamb_colu,gambiae,False,True,True,False
+BP0015-C,Gba_1_15,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.03,0.002,gamb_colu,gambiae,False,True,True,False
+BP0016-C,Gba_2_16,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,M,0.03,0.003,gamb_colu,gambiae,False,True,True,False
+BP0017-C,Gba_2_17,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,M,0.033,0.003,gamb_colu,gambiae,False,True,True,False
+BP0018-C,Gba_2_18,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.032,0.003,gamb_colu,gambiae,False,True,True,False
+BP0019-C,Gba_2_19,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.033,0.002,gamb_colu,gambiae,False,True,True,False
+BP0020-C,Gba_2_20,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+BP0021-C,Gba_2_21,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,M,0.02,0.003,gamb_colu,gambiae,False,True,True,False
+BP0022-C,Gba_2_22,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+BP0023-C,Gba_2_23,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,M,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+BP0024-C,Gba_2_24,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.02,0.002,gamb_colu,gambiae,False,True,True,False
+BP0025-C,Gba_2_25,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+BP0026-C,Gba_2_26,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+BP0027-C,Gba_3_27,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.021,0.003,gamb_colu,gambiae,False,True,True,False
+BP0028-C,Gba_3_28,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.028,0.003,gamb_colu,gambiae,False,True,True,False
+BP0029-C,Gba_3_29,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,M,0.03,0.003,gamb_colu,gambiae,False,True,True,False
+BP0030-C,Gba_3_30,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.025,0.003,gamb_colu,gambiae,False,True,True,False
+BP0031-C,Gba_3_31,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.031,0.003,gamb_colu,gambiae,False,True,True,False
+BP0032-C,Gba_3_32,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.023,0.003,gamb_colu,gambiae,False,True,True,False
+BP0033-C,Gba_3_33,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.016,0.003,gamb_colu,gambiae,False,True,True,False
+BP0034-C,Gba_4_34,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,M,0.02,0.003,gamb_colu,gambiae,False,True,True,False
+BP0035-C,Gba_4_35,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,M,0.023,0.003,gamb_colu,gambiae,False,True,True,False
+BP0036-C,Gba_4_36,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+BP0037-C,Gba_4_37,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+BP0038-C,Gba_4_38,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+BP0039-C,Gba_4_39,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,M,0.021,0.003,gamb_colu,gambiae,False,True,True,False
+BP0040-C,Gba_4_40,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,M,0.024,0.003,gamb_colu,gambiae,False,True,True,False
+BP0041-C,Gba_4_41,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+BP0042-C,Gba_4_42,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+BP0043-C,Gba_4_43,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+BP0044-C,Gba_4_44,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,M,0.021,0.003,gamb_colu,gambiae,False,True,True,False
+BP0045-C,Gba_5_45,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,M,0.034,0.003,gamb_colu,gambiae,False,True,True,False
+BP0046-C,Gba_5_46,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,M,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+BP0047-C,Gba_5_47,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,M,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+BP0048-C,Gba_5_48,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.032,0.002,gamb_colu,gambiae,False,True,True,False
+BP0049-C,Gba_5_49,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+BP0050-C,Gba_5_50,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+BP0051-C,Gba_5_51,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,M,0.034,0.003,gamb_colu,gambiae,False,True,True,False
+BP0052-C,Gba_5_52,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,M,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+BP0053-C,Gba_5_53,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,M,0.016,0.003,gamb_colu,gambiae,False,True,True,False
+BP0054-C,Gba_5_54,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,M,0.031,0.003,gamb_colu,gambiae,False,True,True,False
+BP0055-C,Gba_5_55,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,M,0.017,0.003,gamb_colu,gambiae,False,True,True,False
+BP0056-C,Gba_5_56,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,M,0.013,0.003,gamb_colu,gambiae,False,True,True,False
+BP0057-C,Gba_5_57,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.017,0.003,gamb_colu,gambiae,False,True,True,False
+BP0058-C,Gba_5_58,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+BP0059-C,Gba_5_59,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,M,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+BP0060-C,Gba_5_60,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,M,0.029,0.003,gamb_colu,gambiae,False,True,True,False
+BP0061-C,Gba_6_61,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,M,0.036,0.002,gamb_colu,gambiae,False,True,True,False
+BP0062-C,Gba_6_62,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.021,0.003,gamb_colu,gambiae,False,True,True,False
+BP0064-C,Gba_6_64,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,M,0.017,0.003,gamb_colu,gambiae,False,True,True,False
+BP0065-C,Gba_6_65,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,M,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+BP0066-C,Gba_6_66,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.012,0.002,gamb_colu,gambiae,False,True,True,False
+BP0067-C,Gba_6_67,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,M,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+BP0069-C,Gba_7_69,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.03,0.002,gamb_colu,gambiae,False,True,True,False
+BP0070-C,Gba_7_70,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.031,0.002,gamb_colu,gambiae,False,True,True,False
+BP0071-C,Gba_7_71,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.031,0.002,gamb_colu,gambiae,False,True,True,False
+BP0072-C,Gba_7_72,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+BP0074-C,Gba_7_74,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,M,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+BP0075-C,Gba_7_75,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+BP0076-C,Gba_7_76,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+BP0077-C,Gba_7_77,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+BP0078-C,Gba_7_78,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+BP0079-C,Gba_7_79,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+BP0080-C,Gba_7_80,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+BP0081-C,Gba_7_81,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.02,0.002,gamb_colu,gambiae,False,True,True,False
+BP0001-C,Gba_1_1,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,M,0.022,0.003,gamb_colu,gambiae,False,True,True,False
+BP0002-C,Gba_1_2,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,M,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+BP0003-C,Gba_1_3,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.031,0.002,gamb_colu,gambiae,False,True,True,False
+BP0004-C,Gba_1_4,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,M,0.031,0.002,gamb_colu,gambiae,False,True,True,False
+BP0006-C,Gba_1_6,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+BP0007-C,Gba_1_7,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+BP0008-C,Gba_1_8,AG1000G-CD,Democratic Republic of Congo,Gbadolite,2015,7,4.283,21.017,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+BK0001-C,RCA_1,AG1000G-CF,Central African Republic,Bangui,1993,12,4.367,18.583,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+BK0002-C,RCA_2,AG1000G-CF,Central African Republic,Bangui,1993,12,4.367,18.583,F,0.956,0.002,gamb_colu,coluzzii,False,True,False,True
+BK0003-C,RCA_3,AG1000G-CF,Central African Republic,Bangui,1993,12,4.367,18.583,F,0.964,0.002,gamb_colu,coluzzii,False,True,False,True
+BK0005-C,RCA_5,AG1000G-CF,Central African Republic,Bangui,1993,12,4.367,18.583,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+BK0006-C,RCA_6,AG1000G-CF,Central African Republic,Bangui,1993,12,4.367,18.583,F,0.964,0.002,gamb_colu,coluzzii,False,True,False,True
+BK0007-C,RCA_7,AG1000G-CF,Central African Republic,Bangui,1993,12,4.367,18.583,F,0.957,0.002,gamb_colu,coluzzii,False,True,False,True
+BK0008-C,RCA_8,AG1000G-CF,Central African Republic,Bangui,1993,12,4.367,18.583,F,0.956,0.002,gamb_colu,coluzzii,False,True,False,True
+BK0009-C,RCA_10,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.024,0.003,gamb_colu,gambiae,False,True,True,False
+BK0010-C,RCA_11,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+BK0011-C,RCA_12,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.032,0.002,gamb_colu,gambiae,False,True,True,False
+BK0013-C,RCA_14,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+BK0014-C,RCA_15,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.956,0.002,gamb_colu,coluzzii,False,True,False,True
+BK0015-C,RCA_16,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.953,0.002,gamb_colu,coluzzii,False,True,False,True
+BK0016-C,RCA_17,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+BK0017-C,RCA_19,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.963,0.002,gamb_colu,coluzzii,False,True,False,True
+BK0018-C,RCA_20,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+BK0019-C,RCA_21,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+BK0021-C,RCA_24,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.966,0.002,gamb_colu,coluzzii,False,True,False,True
+BK0022-C,RCA_25,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+BK0023-C,RCA_27,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+BK0024-C,RCA_28,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.961,0.002,gamb_colu,coluzzii,False,True,False,True
+BK0025-C,RCA_29,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.953,0.002,gamb_colu,coluzzii,False,True,False,True
+BK0026-C,RCA_32,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.014,0.002,gamb_colu,gambiae,False,True,True,False
+BK0027-C,RCA_33,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.032,0.002,gamb_colu,gambiae,False,True,True,False
+BK0029-C,RCA_35,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.032,0.002,gamb_colu,gambiae,False,True,True,False
+BK0030-C,RCA_36,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+BK0031-C,RCA_37,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.962,0.002,gamb_colu,coluzzii,False,True,False,True
+BK0032-C,RCA_38,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.029,0.003,gamb_colu,gambiae,False,True,True,False
+BK0033-C,RCA_39,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.037,0.002,gamb_colu,gambiae,False,True,True,False
+BK0034-C,RCA_40,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.02,0.002,gamb_colu,gambiae,False,True,True,False
+BK0035-C,RCA_41,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.956,0.002,gamb_colu,coluzzii,False,True,False,True
+BK0037-C,RCA_43,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+BK0038-C,RCA_44,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.037,0.002,gamb_colu,gambiae,False,True,True,False
+BK0039-C,RCA_45,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+BK0040-C,RCA_46,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.028,0.002,gamb_colu,gambiae,False,True,True,False
+BK0041-C,RCA_48,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.955,0.002,gamb_colu,coluzzii,False,True,False,True
+BK0042-C,RCA_49,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.953,0.002,gamb_colu,coluzzii,False,True,False,True
+BK0043-C,RCA_50,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.033,0.002,gamb_colu,gambiae,False,True,True,False
+BK0045-C,RCA_52,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+BK0046-C,RCA_53,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.019,0.002,gamb_colu,gambiae,False,True,True,False
+BK0047-C,RCA_54,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+BK0048-C,RCA_55,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+BK0049-C,RCA_56,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+BK0050-C,RCA_57,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+BK0051-C,RCA_58,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.019,0.002,gamb_colu,gambiae,False,True,True,False
+BK0053-C,RCA_60,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+BK0054-C,RCA_61,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+BK0055-C,RCA_62,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+BK0056-C,RCA_63,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+BK0057-C,RCA_64,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+BK0058-C,RCA_65,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+BK0059-C,RCA_66,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.038,0.002,gamb_colu,gambiae,False,True,True,False
+BK0061-C,RCA_68,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+BK0062-C,RCA_69,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.019,0.003,gamb_colu,gambiae,False,True,True,False
+BK0063-C,RCA_70,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.025,0.003,gamb_colu,gambiae,False,True,True,False
+BK0064-C,RCA_71,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.016,0.002,gamb_colu,gambiae,False,True,True,False
+BK0065-C,RCA_72,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.971,0.002,gamb_colu,coluzzii,False,True,False,True
+BK0066-C,RCA_73,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.033,0.002,gamb_colu,gambiae,False,True,True,False
+BK0067-C,RCA_74,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.948,0.002,gamb_colu,coluzzii,False,True,False,True
+BK0069-C,RCA_76,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+BK0070-C,RCA_77,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+BK0071-C,RCA_78,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.043,0.002,gamb_colu,gambiae,False,True,True,False
+BK0072-C,RCA_79,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+BK0074-C,RCA_81,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.03,0.002,gamb_colu,gambiae,False,True,True,False
+BK0077-C,RCA_84,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.02,0.002,gamb_colu,gambiae,False,True,True,False
+BK0078-C,RCA_85,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.023,0.003,gamb_colu,gambiae,False,True,True,False
+BK0080-C,RCA_88,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.028,0.002,gamb_colu,gambiae,False,True,True,False
+BK0081-C,RCA_89,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.963,0.002,gamb_colu,coluzzii,False,True,False,True
+BK0082-C,RCA_90,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.017,0.002,gamb_colu,gambiae,False,True,True,False
+BK0083-C,RCA_91,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+BK0085-C,RCA_93,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+BK0086-C,RCA_94,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+BK0094-CW,RCA_102,AG1000G-CF,Central African Republic,Bangui,1994,1,4.367,18.583,F,0.038,0.003,gamb_colu,gambiae,False,True,True,False
+AY0072-C,Tia_dPM_2,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.978,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0062-C,Tia_dPM_10,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.964,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0055-C,Tia_dPM_55,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.974,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0034-C,Tia_dPM_49,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.965,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0078-C,Tia_aPM_5,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.962,0.003,gamb_colu,coluzzii,False,True,False,True
+AY0033-C,Tia_dPM_42,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.975,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0064-C,Tia_dPM_25,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.953,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0032-C,Tia_dPM_36,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.945,0.003,gamb_colu,coluzzii,False,True,False,True
+AY0067-C,Tia_aPM_6,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.963,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0059-C,Tia_aPM_36,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.951,0.003,gamb_colu,coluzzii,False,True,False,True
+AY0027-C,Tia_aPM_38,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.966,0.003,gamb_colu,coluzzii,False,True,False,True
+AY0060-C,Tia_aPM_30,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.957,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0061-C,Tia_dPM_3,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.967,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0031-C,Tia_dPM_28,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.968,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0091-C,Tia_aPM_37,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.966,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0052-C,Tia_dPM_19,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.973,0.003,gamb_colu,coluzzii,False,True,False,True
+AY0021-C,Tia_dPM_37,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.967,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0045-C,Tia_aPM_9,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.966,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0068-C,Tia_aPM_15,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.98,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0016-C,Tia_aPM_32,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.965,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0039-C,Tia_dPM_5,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.97,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0042-C,Tia_dPM_27,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.963,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0088-C,Tia_dPM_52,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.963,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0015-C,Tia_aPM_41,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.973,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0020-C,Tia_dPM_29,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.961,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0077-C,Tia_dPM_53,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.971,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0049-C,Tia_aPM_40,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.957,0.003,gamb_colu,coluzzii,False,True,False,True
+AY0029-C,Tia_dPM_13,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.972,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0040-C,Tia_dPM_12,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.976,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0054-C,Tia_dPM_33,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.972,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0046-C,Tia_aPM_18,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.965,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0057-C,Tia_aPM_17,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.963,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0025-C,Tia_aPM_11,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.975,0.003,gamb_colu,coluzzii,False,True,False,True
+AY0069-C,Tia_aPM_24,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.96,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0070-C,Tia_aPM_35,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.964,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0028-C,Tia_dPM_6,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.966,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0073-C,Tia_dPM_9,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.966,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0084-C,Tia_dPM_24,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.972,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0075-C,Tia_dPM_40,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.963,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0014-C,Tia_aPM_12,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.968,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0092-C,Tia_aPM_33,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.968,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0087-C,Tia_dPM_46,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.97,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0044-C,Tia_dPM_41,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.972,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0071-C,Tia_aPM_20,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.978,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0090-C,Tia_aPM_13,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.983,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0026-C,Tia_aPM_28,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.965,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0050-C,Tia_dPM_4,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.956,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0041-C,Tia_dPM_20,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.955,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0085-C,Tia_dPM_31,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.961,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0023-C,Tia_dPM_50,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.964,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0038-C,Tia_aPM_31,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.972,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0007-C,Tia_dPM_16,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.966,0.003,gamb_colu,coluzzii,False,True,False,True
+AY0018-C,Tia_dPM_14,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.968,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0019-C,Tia_dPM_22,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.963,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0086-C,Tia_dPM_39,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.977,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0076-C,Tia_dPM_47,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.967,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0079-C,Tia_aPM_14,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.952,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0082-C,Tia_aPM_29,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.97,0.003,gamb_colu,coluzzii,False,True,False,True
+AY0006-C,Tia_dPM_8,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.964,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0083-C,Tia_dPM_1,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.971,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0063-C,Tia_dPM_18,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.97,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0011-C,Tia_dPM_44,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.971,0.003,gamb_colu,coluzzii,False,True,False,True
+AY0012-C,Tia_dPM_51,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.962,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0047-C,Tia_aPM_26,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.971,0.003,gamb_colu,coluzzii,False,True,False,True
+AY0010-C,Tia_dPM_38,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.964,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0035-C,Tia_aPM_19,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.969,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0074-C,Tia_dPM_17,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.969,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0056-C,Tia_aPM_8,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.972,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0089-C,Tia_aPM_4,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.973,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0048-C,Tia_aPM_27,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.965,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0053-C,Tia_dPM_26,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.968,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0065-C,Tia_dPM_48,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.969,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0066-C,Tia_dPM_54,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.972,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0024-C,Tia_aPM_1,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.964,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0080-C,Tia_aPM_23,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.955,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0017-C,Tia_dPM_7,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.952,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0043-C,Tia_dPM_34,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.955,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0013-C,Tia_aPM_3,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.97,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0036-C,Tia_aPM_10,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.985,0.002,gamb_colu,coluzzii,False,True,False,True
+AY0058-C,Tia_aPM_25,AG1000G-CI,Cote d'Ivoire,Tiassale,2012,-1,5.898,-4.823,F,0.973,0.003,gamb_colu,coluzzii,False,True,False,True
+AN0007-C,CM0901778,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+AN0008-C,CM0901779,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AN0009-C,CM0901780,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AN0010-C,CM0901782,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.015,0.002,gamb_colu,gambiae,False,True,True,False
+AN0011-C,CM0901783,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.017,0.002,gamb_colu,gambiae,False,True,True,False
+AN0012-C,CM0901784,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.02,0.002,gamb_colu,gambiae,False,True,True,False
+AN0013-C,CM0901785,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AN0014-C,CM0901786,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.032,0.002,gamb_colu,gambiae,False,True,True,False
+AN0015-C,CM0901787,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.016,0.002,gamb_colu,gambiae,False,True,True,False
+AN0016-C,CM0901789,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.031,0.003,gamb_colu,gambiae,False,True,True,False
+AN0017-Cx,CM0901790,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AN0018-C,CM0901791,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AN0019-C,CM0901792,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.03,0.002,gamb_colu,gambiae,False,True,True,False
+AN0020-C,CM0901794,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.033,0.002,gamb_colu,gambiae,False,True,True,False
+AN0021-C,CM0901795,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.019,0.002,gamb_colu,gambiae,False,True,True,False
+AN0022-C,CM0902285,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,M,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AN0023-C,CM0902286,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,M,0.023,0.003,gamb_colu,gambiae,False,True,True,False
+AN0024-C,CM0902287,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,M,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AN0025-Cx,CM0902288,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,M,0.031,0.002,gamb_colu,gambiae,False,True,True,False
+AN0026-Cx,CM0902289,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,M,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AN0027-C,CM0902290,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,M,0.028,0.003,gamb_colu,gambiae,False,True,True,False
+AN0028-C,CM0902291,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,M,0.028,0.002,gamb_colu,gambiae,False,True,True,False
+AN0029-C,CM0902293,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,M,0.021,0.003,gamb_colu,gambiae,False,True,True,False
+AN0030-C,CM0902295,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,M,0.037,0.003,gamb_colu,gambiae,False,True,True,False
+AN0031-C,CM0902296,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,M,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AN0032-C,CM0902297,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,M,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AN0033-C,CM0902298,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,M,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AN0034-C,CM0902327,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,M,0.014,0.003,gamb_colu,gambiae,False,True,True,False
+AN0035-C,CM0902328,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,M,0.02,0.002,gamb_colu,gambiae,False,True,True,False
+AN0036-C,CM0902333,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,M,0.041,0.002,gamb_colu,gambiae,False,True,True,False
+AN0037-C,CM0902262,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AN0038-C,CM0902263,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AN0039-C,CM0902265,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.017,0.002,gamb_colu,gambiae,False,True,True,False
+AN0040-C,CM0902266,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.03,0.002,gamb_colu,gambiae,False,True,True,False
+AN0041-C,CM0902267,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AN0042-C,CM0902268,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AN0043-C,CM0902269,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+AN0044-C,CM0902273,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AN0045-C,CM0902274,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.022,0.003,gamb_colu,gambiae,False,True,True,False
+AN0046-C,CM0902275,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AN0047-C,CM0902277,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.017,0.003,gamb_colu,gambiae,False,True,True,False
+AN0048-C,CM0902278,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.015,0.002,gamb_colu,gambiae,False,True,True,False
+AN0049-C,CM0902279,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.028,0.002,gamb_colu,gambiae,False,True,True,False
+AN0050-C,CM0902280,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AN0051-C,CM0902281,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.017,0.002,gamb_colu,gambiae,False,True,True,False
+AN0053-C,CM0902283,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AN0054-C,CM0902284,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AN0055-C,CM0902299,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.019,0.002,gamb_colu,gambiae,False,True,True,False
+AN0056-C,CM0902300,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.091,0.002,gamb_colu,gambiae,False,True,True,False
+AN0057-C,CM0902305,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AN0058-C,CM0902306,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.016,0.002,gamb_colu,gambiae,False,True,True,False
+AN0059-C,CM0902308,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AN0060-C,CM0902309,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AN0061-Cx,CM0901968,AG1000G-CM-A,Cameroon,Zembe Borongo,2009,9,5.747,14.442,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AN0062-C,CM0901969,AG1000G-CM-A,Cameroon,Zembe Borongo,2009,9,5.747,14.442,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AN0063-Cx,CM0901970,AG1000G-CM-A,Cameroon,Zembe Borongo,2009,9,5.747,14.442,F,0.033,0.002,gamb_colu,gambiae,False,True,True,False
+AN0064-C,CM0901971,AG1000G-CM-A,Cameroon,Zembe Borongo,2009,9,5.747,14.442,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AN0065-Cx,CM0901974,AG1000G-CM-A,Cameroon,Zembe Borongo,2009,9,5.747,14.442,F,0.014,0.002,gamb_colu,gambiae,False,True,True,False
+AN0066-C,CM0901975,AG1000G-CM-A,Cameroon,Zembe Borongo,2009,9,5.747,14.442,F,0.031,0.002,gamb_colu,gambiae,False,True,True,False
+AN0067-Cx,CM0902002,AG1000G-CM-A,Cameroon,Zembe Borongo,2009,9,5.747,14.442,F,0.017,0.002,gamb_colu,gambiae,False,True,True,False
+AN0068-Cx,CM0902006,AG1000G-CM-A,Cameroon,Zembe Borongo,2009,9,5.747,14.442,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AN0069-C,CM0902007,AG1000G-CM-A,Cameroon,Zembe Borongo,2009,9,5.747,14.442,F,0.015,0.002,gamb_colu,gambiae,False,True,True,False
+AN0070-C,CM0902023,AG1000G-CM-A,Cameroon,Zembe Borongo,2009,9,5.747,14.442,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AN0071-C,CM0902025,AG1000G-CM-A,Cameroon,Zembe Borongo,2009,9,5.747,14.442,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AN0072-Cx,CM0902028,AG1000G-CM-A,Cameroon,Zembe Borongo,2009,9,5.747,14.442,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AN0073-C,CM0902029,AG1000G-CM-A,Cameroon,Zembe Borongo,2009,9,5.747,14.442,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AN0074-C,CM0902030,AG1000G-CM-A,Cameroon,Zembe Borongo,2009,9,5.747,14.442,F,0.028,0.002,gamb_colu,gambiae,False,True,True,False
+AN0075-Cx,CM0902031,AG1000G-CM-A,Cameroon,Zembe Borongo,2009,9,5.747,14.442,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AN0076-C,CM0902072,AG1000G-CM-A,Cameroon,Zembe Borongo,2009,9,5.747,14.442,F,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+AN0077-C,CM0902073,AG1000G-CM-A,Cameroon,Zembe Borongo,2009,9,5.747,14.442,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AN0078-C,CM0902074,AG1000G-CM-A,Cameroon,Zembe Borongo,2009,9,5.747,14.442,F,0.02,0.003,gamb_colu,gambiae,False,True,True,False
+AN0079-C,CM0902077,AG1000G-CM-A,Cameroon,Zembe Borongo,2009,9,5.747,14.442,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AN0080-C,CM0902078,AG1000G-CM-A,Cameroon,Zembe Borongo,2009,9,5.747,14.442,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AN0081-C,CM0902079,AG1000G-CM-A,Cameroon,Zembe Borongo,2009,9,5.747,14.442,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AN0082-C,CM0902080,AG1000G-CM-A,Cameroon,Zembe Borongo,2009,9,5.747,14.442,F,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+AN0083-C,CM0902081,AG1000G-CM-A,Cameroon,Zembe Borongo,2009,9,5.747,14.442,F,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+AN0084-C,CM0902082,AG1000G-CM-A,Cameroon,Zembe Borongo,2009,9,5.747,14.442,F,0.02,0.002,gamb_colu,gambiae,False,True,True,False
+AN0085-C,CM0902128,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AN0086-C,CM0902131,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AN0087-C,CM0902133,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.028,0.002,gamb_colu,gambiae,False,True,True,False
+AN0088-C,CM0902156,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AN0089-C,CM0902157,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AN0090-C,CM0902158,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.019,0.002,gamb_colu,gambiae,False,True,True,False
+AN0091-C,CM0902159,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AN0092-C,CM0902161,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+AN0093-C,CM0902162,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.018,0.003,gamb_colu,gambiae,False,True,True,False
+AN0094-C,CM0902163,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+AN0095-C,CM0902164,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AN0096-C,CM0902166,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AN0097-C,CM0902172,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+AN0098-C,CM0902174,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+AN0099-C,CM0902206,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.09,0.002,gamb_colu,gambiae,False,True,True,False
+AN0100-C,CM0902207,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AN0101-Cx,CM0902229,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.02,0.002,gamb_colu,gambiae,False,True,True,False
+AN0102-C,CM0902232,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.028,0.002,gamb_colu,gambiae,False,True,True,False
+AN0103-C,CM0902244,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AN0104-C,CM0902301,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.017,0.002,gamb_colu,gambiae,False,True,True,False
+AN0105-C,CM0902302,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.019,0.002,gamb_colu,gambiae,False,True,True,False
+AN0106-C,CM0902303,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.017,0.002,gamb_colu,gambiae,False,True,True,False
+AN0107-C,CM0902304,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AN0108-C,CM0902307,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.02,0.002,gamb_colu,gambiae,False,True,True,False
+AN0109-C,CM0902331,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AN0111-C,CM0902342,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+AN0112-Cx,CM0902343,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AN0113-C,CM0902354,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AN0114-C,CM0902357,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AN0115-C,CM0902358,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AN0117-C,CM0902364,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AN0118-Cx,CM0902365,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AN0119-C,CM0902366,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AN0120-C,CM0902372,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+AN0121-Cx,CM0902373,AG1000G-CM-A,Cameroon,Gado Badzere,2009,9,5.747,14.442,F,0.014,0.002,gamb_colu,gambiae,False,True,True,False
+AN0122-C,CM0901767,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,M,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+AN0123-Cx,CM0901768,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,M,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AN0124-C,CM0901769,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,M,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AN0125-Cx,CM0901770,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,M,0.028,0.002,gamb_colu,gambiae,False,True,True,False
+AN0126-C,CM0901771,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,M,0.025,0.003,gamb_colu,gambiae,False,True,True,False
+AN0127-Cx,CM0901772,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,M,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AN0128-C,CM0901773,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,M,0.033,0.002,gamb_colu,gambiae,False,True,True,False
+AN0129-C,CM0901774,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,M,0.036,0.002,gamb_colu,gambiae,False,True,True,False
+AN0130-C,CM0901775,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,M,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AN0131-C,CM0901776,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,M,0.021,0.003,gamb_colu,gambiae,False,True,True,False
+AN0132-Cx,CM0901777,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,M,0.03,0.002,gamb_colu,gambiae,False,True,True,False
+AN0133-Cx,CM0901847,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,M,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AN0134-Cx,CM0901852,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,M,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AN0135-Cx,CM0901853,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,M,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AN0136-Cx,CM0901855,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,M,0.033,0.002,gamb_colu,gambiae,False,True,True,False
+AN0137-C,CM0901587,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.017,0.002,gamb_colu,gambiae,False,True,True,False
+AN0138-C,CM0901588,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AN0139-C,CM0901589,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.019,0.002,gamb_colu,gambiae,False,True,True,False
+AN0140-C,CM0901590,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AN0141-C,CM0901591,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.019,0.002,gamb_colu,gambiae,False,True,True,False
+AN0142-C,CM0901592,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.033,0.002,gamb_colu,gambiae,False,True,True,False
+AN0143-C,CM0901593,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.028,0.003,gamb_colu,gambiae,False,True,True,False
+AN0144-C,CM0901594,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.019,0.003,gamb_colu,gambiae,False,True,True,False
+AN0146-C,CM0901596,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.025,0.003,gamb_colu,gambiae,False,True,True,False
+AN0147-C,CM0901597,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+AN0148-C,CM0901598,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.022,0.003,gamb_colu,gambiae,False,True,True,False
+AN0149-C,CM0901599,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AN0151-C,CM0901601,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.032,0.002,gamb_colu,gambiae,False,True,True,False
+AN0152-C,CM0901602,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.028,0.002,gamb_colu,gambiae,False,True,True,False
+AN0153-C,CM0901603,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AN0154-C,CM0901604,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AN0155-C,CM0901605,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AN0156-C,CM0901606,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AN0157-Cx,CM0901607,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AN0158-C,CM0901608,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AN0159-Cx,CM0901609,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AN0160-Cx,CM0901610,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.028,0.002,gamb_colu,gambiae,False,True,True,False
+AN0162-Cx,CM0901612,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+AN0163-C,CM0901613,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.02,0.002,gamb_colu,gambiae,False,True,True,False
+AN0164-C,CM0901615,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.014,0.002,gamb_colu,gambiae,False,True,True,False
+AN0165-C,CM0901616,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AN0166-C,CM0901617,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.019,0.002,gamb_colu,gambiae,False,True,True,False
+AN0167-C,CM0901618,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AN0168-C,CM0901619,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AN0169-C,CM0901620,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AN0170-C,CM0901621,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AN0171-C,CM0901623,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.016,0.002,gamb_colu,gambiae,False,True,True,False
+AN0172-C,CM0901624,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AN0173-C,CM0901625,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.019,0.002,gamb_colu,gambiae,False,True,True,False
+AN0174-Cx,CM0901626,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AN0175-C,CM0901627,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AN0176-C,CM0901628,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AN0177-C,CM0901629,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AN0178-C,CM0901630,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.014,0.002,gamb_colu,gambiae,False,True,True,False
+AN0179-C,CM0901631,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AN0180-C,CM0901632,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AN0181-C,CM0901633,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AN0182-C,CM0901635,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.015,0.002,gamb_colu,gambiae,False,True,True,False
+AN0183-C,CM0901636,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AN0184-C,CM0901553,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AN0185-C,CM0901554,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.017,0.002,gamb_colu,gambiae,False,True,True,False
+AN0186-Cx,CM0901555,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AN0187-C,CM0901556,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+AN0188-C,CM0901558,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.02,0.002,gamb_colu,gambiae,False,True,True,False
+AN0189-C,CM0901559,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.013,0.002,gamb_colu,gambiae,False,True,True,False
+AN0190-C,CM0901560,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AN0191-C,CM0901561,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+AN0192-C,CM0901562,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+AN0193-Cx,CM0901564,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.032,0.002,gamb_colu,gambiae,False,True,True,False
+AN0194-C,CM0901565,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.016,0.002,gamb_colu,gambiae,False,True,True,False
+AN0195-Cx,CM0901567,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AN0196-C,CM0901568,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AN0197-Cx,CM0901570,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AN0198-C,CM0901572,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AN0199-C,CM0901573,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AN0200-C,CM0901575,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.032,0.002,gamb_colu,gambiae,False,True,True,False
+AN0201-Cx,CM0901576,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AN0202-Cx,CM0901578,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+AN0203-Cx,CM0901579,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+AN0204-C,CM0901580,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+AN0205-C,CM0901581,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+AN0206-C,CM0901582,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AN0207-C,CM0901583,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AN0208-C,CM0901584,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AN0209-C,CM0901585,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.018,0.003,gamb_colu,gambiae,False,True,True,False
+AN0210-Cx,CM0901793,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.017,0.002,gamb_colu,gambiae,False,True,True,False
+AN0212-C,CM0901801,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AN0213-C,CM0901803,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AN0214-C,CM0901804,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AN0215-C,CM0901805,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.03,0.002,gamb_colu,gambiae,False,True,True,False
+AN0217-C,CM0901808,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.026,0.003,gamb_colu,gambiae,False,True,True,False
+AN0218-C,CM0901809,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.03,0.002,gamb_colu,gambiae,False,True,True,False
+AN0219-C,CM0901810,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AN0220-C,CM0901814,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.036,0.002,gamb_colu,gambiae,False,True,True,False
+AN0221-C,CM0901818,AG1000G-CM-A,Cameroon,Mayos,2009,9,4.341,13.558,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AN0222-Cx,CM0901912,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,M,0.039,0.002,gamb_colu,gambiae,False,True,True,False
+AN0223-C,CM0901913,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,M,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AN0224-Cx,CM0901914,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,M,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AN0225-Cx,CM0901915,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,M,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AN0226-Cx,CM0901916,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,M,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+AN0227-Cx,CM0901917,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,M,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+AN0228-C,CM0901918,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,M,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AN0229-Cx,CM0901919,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,M,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AN0230-Cx,CM0901950,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,M,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AN0231-Cx,CM0901951,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,M,0.016,0.002,gamb_colu,gambiae,False,True,True,False
+AN0232-C,CM0901952,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,M,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AN0233-C,CM0901953,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,M,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AN0234-C,CM0901954,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,M,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AN0235-C,CM0901955,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,M,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AN0236-Cx,CM0901956,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,M,0.022,0.003,gamb_colu,gambiae,False,True,True,False
+AN0237-Cx,CM0901857,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.086,0.002,gamb_colu,gambiae,False,True,True,False
+AN0238-C,CM0901858,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.02,0.002,gamb_colu,gambiae,False,True,True,False
+AN0239-C,CM0901859,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AN0240-C,CM0901864,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.02,0.002,gamb_colu,gambiae,False,True,True,False
+AN0241-C,CM0901865,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AN0242-C,CM0901866,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AN0243-C,CM0901867,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.02,0.003,gamb_colu,gambiae,False,True,True,False
+AN0244-C,CM0901868,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.02,0.002,gamb_colu,gambiae,False,True,True,False
+AN0245-C,CM0901872,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AN0246-C,CM0901873,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.03,0.002,gamb_colu,gambiae,False,True,True,False
+AN0247-C,CM0901878,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.034,0.002,gamb_colu,gambiae,False,True,True,False
+AN0248-C,CM0901880,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.034,0.002,gamb_colu,gambiae,False,True,True,False
+AN0250-C,CM0901882,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.035,0.002,gamb_colu,gambiae,False,True,True,False
+AN0251-C,CM0901883,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.028,0.002,gamb_colu,gambiae,False,True,True,False
+AN0252-C,CM0901885,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AN0253-C,CM0901886,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.017,0.002,gamb_colu,gambiae,False,True,True,False
+AN0254-C,CM0901887,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AN0255-C,CM0901888,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.019,0.002,gamb_colu,gambiae,False,True,True,False
+AN0256-C,CM0901889,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.028,0.002,gamb_colu,gambiae,False,True,True,False
+AN0258-C,CM0901891,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AN0259-Cx,CM0901892,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AN0260-C,CM0901893,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AN0261-Cx,CM0901894,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AN0262-C,CM0901895,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AN0263-Cx,CM0901896,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AN0264-C,CM0901897,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+AN0265-C,CM0901898,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.067,0.002,gamb_colu,gambiae,False,True,True,False
+AN0266-C,CM0901899,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.04,0.003,gamb_colu,gambiae,False,True,True,False
+AN0267-Cx,CM0901901,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AN0268-C,CM0901902,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AN0269-C,CM0901903,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.013,0.002,gamb_colu,gambiae,False,True,True,False
+AN0270-C,CM0901905,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.016,0.002,gamb_colu,gambiae,False,True,True,False
+AN0271-C,CM0901906,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AN0272-C,CM0901937,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AN0275-C,CM0901940,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AN0276-C,CM0901941,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AN0277-C,CM0901942,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.037,0.002,gamb_colu,gambiae,False,True,True,False
+AN0278-C,CM0901943,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AN0279-C,CM0901944,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AN0280-C,CM0901181,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.028,0.002,gamb_colu,gambiae,False,True,True,False
+AN0281-C,CM0901182,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.038,0.002,gamb_colu,gambiae,False,True,True,False
+AN0282-Cx,CM0901183,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AN0283-Cx,CM0901191,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AN0284-Cx,CM0901193,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.019,0.002,gamb_colu,gambiae,False,True,True,False
+AN0285-C,CM0901201,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AN0286-Cx,CM0901214,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.03,0.002,gamb_colu,gambiae,False,True,True,False
+AN0287-Cx,CM0901239,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.016,0.002,gamb_colu,gambiae,False,True,True,False
+AN0288-Cx,CM0901240,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AN0289-C,CM0901241,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.028,0.002,gamb_colu,gambiae,False,True,True,False
+AN0290-Cx,CM0901242,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AN0291-Cx,CM0901243,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.036,0.002,gamb_colu,gambiae,False,True,True,False
+AN0292-C,CM0901244,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AN0293-Cx,CM0901245,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.033,0.003,gamb_colu,gambiae,False,True,True,False
+AN0294-C,CM0901280,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AN0295-C,CM0901281,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.02,0.002,gamb_colu,gambiae,False,True,True,False
+AN0296-Cx,CM0901284,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+AN0297-C,CM0901285,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.033,0.002,gamb_colu,gambiae,False,True,True,False
+AN0298-Cx,CM0901286,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.015,0.002,gamb_colu,gambiae,False,True,True,False
+AN0299-C,CM0901287,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.016,0.002,gamb_colu,gambiae,False,True,True,False
+AN0300-C,CM0901324,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AN0301-Cx,CM0901325,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AN0302-C,CM0901388,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AN0303-C,CM0901395,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AN0304-C,CM0901396,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AN0305-C,CM0901397,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.037,0.002,gamb_colu,gambiae,False,True,True,False
+AN0306-C,CM0901398,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+AN0307-C,CM0901399,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.016,0.002,gamb_colu,gambiae,False,True,True,False
+AN0308-C,CM0901400,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AN0309-Cx,CM0901403,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AN0310-C,CM0901404,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AN0311-C,CM0901405,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.028,0.002,gamb_colu,gambiae,False,True,True,False
+AN0312-C,CM0901407,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AN0313-C,CM0901410,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.028,0.002,gamb_colu,gambiae,False,True,True,False
+AN0314-C,CM0901412,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AN0315-C,CM0901413,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AN0316-C,CM0901414,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+AN0317-C,CM0901860,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.028,0.002,gamb_colu,gambiae,False,True,True,False
+AN0318-C,CM0901861,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AN0319-C,CM0901862,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.017,0.002,gamb_colu,gambiae,False,True,True,False
+AN0320-C,CM0901863,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AN0321-C,CM0901871,AG1000G-CM-A,Cameroon,Daiguene,2009,9,4.777,13.844,F,0.028,0.002,gamb_colu,gambiae,False,True,True,False
+AB0293-C,964,AG1000G-CM-B,Cameroon,Doulougou,2005,-1,10.425,14.242,F,0.014,0.002,gamb_colu,gambiae,False,True,True,False
+AB0294-C,970,AG1000G-CM-B,Cameroon,Doulougou,2005,-1,10.425,14.242,F,0.029,0.003,gamb_colu,gambiae,False,True,True,False
+AB0295-C,972,AG1000G-CM-B,Cameroon,Doulougou,2005,-1,10.425,14.242,F,0.015,0.002,gamb_colu,gambiae,False,True,True,False
+AB0297-C,1041,AG1000G-CM-B,Cameroon,Moussourtouk,2005,-1,10.342,14.236,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AN0418-C,795,AG1000G-CM-B,Cameroon,Makabay (Djarengo),2005,-1,9.774,13.893,F,0.031,0.002,gamb_colu,gambiae,False,True,True,False
+AN0419-C,956,AG1000G-CM-B,Cameroon,Palama,2005,-1,10.462,14.228,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AN0421-C,1060,AG1000G-CM-B,Cameroon,Moulva,2005,-1,10.3,14.254,F,0.013,0.002,gamb_colu,gambiae,False,True,True,False
+AN0423-C,1085,AG1000G-CM-B,Cameroon,Laf,2005,-1,10.256,14.217,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AN0424-C,1111,AG1000G-CM-B,Cameroon,Badjawa,2005,-1,10.211,14.188,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AN0425-C,1123,AG1000G-CM-B,Cameroon,Massila,2005,-1,10.188,14.143,F,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+AN0426-C,1131,AG1000G-CM-B,Cameroon,Massila,2005,-1,10.188,14.143,F,0.019,0.002,gamb_colu,gambiae,False,True,True,False
+AN0427-C,1134,AG1000G-CM-B,Cameroon,Massila,2005,-1,10.188,14.143,F,0.03,0.002,gamb_colu,gambiae,False,True,True,False
+AN0428-C,1135,AG1000G-CM-B,Cameroon,Massila,2005,-1,10.188,14.143,F,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+AN0430-C,1170,AG1000G-CM-B,Cameroon,Morongo,2005,-1,10.102,14.193,F,0.017,0.003,gamb_colu,gambiae,False,True,True,False
+AN0431-C,1191,AG1000G-CM-B,Cameroon,Karba,2005,-1,10.05,14.149,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AN0433-C,4472,AG1000G-CM-B,Cameroon,Otibili,2005,-1,4.332,11.632,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AN0434-C,4687,AG1000G-CM-B,Cameroon,Mbalmayo,2005,-1,3.516,11.5,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AN0435-C,4544,AG1000G-CM-B,Cameroon,Obala,2005,-1,4.166,11.535,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AN0436-C,4625,AG1000G-CM-B,Cameroon,Essos,2005,-1,3.87,11.539,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AN0437-C,4629,AG1000G-CM-B,Cameroon,Ahala,2005,-1,3.805,11.507,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AN0438-C,4635,AG1000G-CM-B,Cameroon,Ahala,2005,-1,3.805,11.507,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AN0440-C,4637,AG1000G-CM-B,Cameroon,Ahala,2005,-1,3.805,11.507,F,0.034,0.002,gamb_colu,gambiae,False,True,True,False
+AN0442-C,4639,AG1000G-CM-B,Cameroon,Ahala,2005,-1,3.805,11.507,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AN0443-C,4448,AG1000G-CM-B,Cameroon,Bamendi,2005,-1,5.479,10.457,F,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+AN0444-C,4451,AG1000G-CM-B,Cameroon,Bamendi,2005,-1,5.479,10.457,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AN0445-C,4455,AG1000G-CM-B,Cameroon,Bamendi,2005,-1,5.479,10.457,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AN0448-C,4468,AG1000G-CM-B,Cameroon,Otibili,2005,-1,4.332,11.632,F,0.021,0.003,gamb_colu,gambiae,False,True,True,False
+AN0449-C,4469,AG1000G-CM-B,Cameroon,Otibili,2005,-1,4.332,11.632,F,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+AN0451-C,4471,AG1000G-CM-B,Cameroon,Otibili,2005,-1,4.332,11.632,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AN0453-C,1117,AG1000G-CM-B,Cameroon,Massila,2005,-1,10.188,14.143,F,0.027,0.003,gamb_colu,gambiae,False,True,True,False
+AN0454-C,735,AG1000G-CM-B,Cameroon,Tchéré,2005,-1,10.708,14.212,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AN0455-C,761,AG1000G-CM-B,Cameroon,Mambang,2005,-1,10.658,14.29,F,0.02,0.002,gamb_colu,gambiae,False,True,True,False
+AN0457-C,896,AG1000G-CM-B,Cameroon,Lougol,2005,-1,10.495,14.255,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AN0458-C,909,AG1000G-CM-B,Cameroon,Lougol,2005,-1,10.495,14.255,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AN0460-C,959,AG1000G-CM-B,Cameroon,Palama,2005,-1,10.462,14.228,F,0.977,0.002,gamb_colu,coluzzii,False,True,False,True
+AN0466-C,1057,AG1000G-CM-B,Cameroon,Moulva,2005,-1,10.3,14.254,F,0.033,0.007,gamb_colu,gambiae,False,True,True,False
+AN0468-C,1072,AG1000G-CM-B,Cameroon,Laf,2005,-1,10.256,14.217,F,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+AN0469-C,1092,AG1000G-CM-B,Cameroon,Laf,2005,-1,10.256,14.217,F,0.09,0.003,gamb_colu,gambiae,False,True,True,False
+AN0470-C,1099,AG1000G-CM-B,Cameroon,Badjawa,2005,-1,10.211,14.188,F,0.02,0.003,gamb_colu,gambiae,False,True,True,False
+AN0471-C,1101,AG1000G-CM-B,Cameroon,Badjawa,2005,-1,10.211,14.188,F,0.02,0.002,gamb_colu,gambiae,False,True,True,False
+AN0474-C,1129,AG1000G-CM-B,Cameroon,Massila,2005,-1,10.188,14.143,F,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+AN0475-C,1205,AG1000G-CM-B,Cameroon,Karba,2005,-1,10.05,14.149,F,0.02,0.002,gamb_colu,gambiae,False,True,True,False
+AN0476-C,1342,AG1000G-CM-B,Cameroon,Mayo Dafan,2005,-1,9.764,13.905,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AN0477-C,1369,AG1000G-CM-B,Cameroon,Sorawel,2005,-1,9.784,13.864,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AN0478-C,1574,AG1000G-CM-B,Cameroon,Mayo Lebride,2005,-1,9.513,13.823,F,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+AN0479-C,1666,AG1000G-CM-B,Cameroon,Dolla,2005,-1,9.438,13.594,F,0.02,0.002,gamb_colu,gambiae,False,True,True,False
+AN0480-C,1708,AG1000G-CM-B,Cameroon,Secamde,2005,-1,9.424,13.56,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AN0485-C,2070,AG1000G-CM-B,Cameroon,Wouro Andre,2005,-1,8.888,13.503,F,0.976,0.002,gamb_colu,coluzzii,False,True,False,True
+AN0486-C,2174,AG1000G-CM-B,Cameroon,Badankali,2005,-1,8.66,13.529,F,0.984,0.002,gamb_colu,coluzzii,False,True,False,True
+AN0487-C,2246,AG1000G-CM-B,Cameroon,Carrefour Poli,2005,-1,8.534,13.53,F,0.978,0.002,gamb_colu,coluzzii,False,True,False,True
+AN0488-C,2260,AG1000G-CM-B,Cameroon,Gouna,2005,-1,8.525,13.564,F,0.977,0.002,gamb_colu,coluzzii,False,True,False,True
+AN0492-C,2458,AG1000G-CM-B,Cameroon,Gamba,2005,-1,8.098,13.599,F,0.992,0.002,gamb_colu,coluzzii,False,True,False,True
+AN0493-C,941,AG1000G-CM-B,Cameroon,Gakle,2005,-1,10.522,14.265,F,0.977,0.002,gamb_colu,coluzzii,False,True,False,True
+VBS02039-4431STDY6672907,3227,AG1000G-CM-B,Cameroon,Birsok,2005,-1,6.997,13.133,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02040-4431STDY6672908,3245,AG1000G-CM-B,Cameroon,Mabarangal'L,2005,-1,6.915,13.132,F,0.038,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02041-4431STDY6672909,3284,AG1000G-CM-B,Cameroon,Tekel,2005,-1,6.806,13.174,F,0.034,0.003,gamb_colu,gambiae,False,True,True,False
+VBS02042-4431STDY6672910,3308,AG1000G-CM-B,Cameroon,Beka Goto,2005,-1,6.751,13.111,F,0.037,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02043-4431STDY6672911,3310,AG1000G-CM-B,Cameroon,Beka Goto,2005,-1,6.751,13.111,F,0.028,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02044-4431STDY6672912,4428,AG1000G-CM-B,Cameroon,Mangoum,2005,-1,5.484,10.593,F,0.02,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02045-4431STDY6672913,4721,AG1000G-CM-B,Cameroon,Avebe,2005,-1,3.369,11.519,F,0.054,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02046-4431STDY6672914,4912,AG1000G-CM-B,Cameroon,Foulassi I,2005,-1,2.817,10.934,F,0.032,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02047-4431STDY6672915,5058,AG1000G-CM-B,Cameroon,Nlozok,2005,-1,2.855,10.056,F,0.03,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02048-4431STDY6672916,5083,AG1000G-CM-B,Cameroon,Dombé,2005,-1,2.949,9.927,F,0.037,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02003-4431STDY6672871,971,AG1000G-CM-B,Cameroon,Doulougou,2005,-1,10.425,14.242,F,0.031,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02004-4431STDY6672872,1006,AG1000G-CM-B,Cameroon,Mounda,2005,-1,10.368,14.228,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02005-4431STDY6672873,1155,AG1000G-CM-B,Cameroon,Morongo,2005,-1,10.102,14.193,F,0.016,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02006-4431STDY6672874,1316,AG1000G-CM-B,Cameroon,Rompo,2005,-1,9.765,13.95,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02007-4431STDY6672875,1467,AG1000G-CM-B,Cameroon,Séboré,2005,-1,9.703,13.859,F,0.023,0.003,gamb_colu,gambiae,False,True,True,False
+VBS02008-4431STDY6672876,1576,AG1000G-CM-B,Cameroon,Mayo Lebride,2005,-1,9.513,13.823,F,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02009-4431STDY6672877,1701,AG1000G-CM-B,Cameroon,Secamde,2005,-1,9.424,13.56,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02010-4431STDY6672878,1911,AG1000G-CM-B,Cameroon,Lainde Mbana,2005,-1,9.119,13.506,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02011-4431STDY6672879,1920,AG1000G-CM-B,Cameroon,Lainde Mbana,2005,-1,9.119,13.506,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02012-4431STDY6672880,2016,AG1000G-CM-B,Cameroon,Lamoudan,2005,-1,8.981,13.533,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02014-4431STDY6672882,2117,AG1000G-CM-B,Cameroon,Carrefour Nari,2005,-1,8.801,13.52,F,0.025,0.003,gamb_colu,gambiae,False,True,True,False
+VBS02015-4431STDY6672883,2138,AG1000G-CM-B,Cameroon,Mayo Boki,2005,-1,8.722,13.54,F,0.028,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02016-4431STDY6672884,2145,AG1000G-CM-B,Cameroon,Mayo Boki,2005,-1,8.722,13.54,F,0.017,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02017-4431STDY6672885,2148,AG1000G-CM-B,Cameroon,Mayo Boki,2005,-1,8.722,13.54,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02018-4431STDY6672886,2243,AG1000G-CM-B,Cameroon,Djamboutou,2005,-1,8.579,13.516,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02020-4431STDY6672888,2303,AG1000G-CM-B,Cameroon,Balda Bouri,2005,-1,8.513,13.603,F,0.028,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02021-4431STDY6672889,2306,AG1000G-CM-B,Cameroon,Balda Bouri,2005,-1,8.513,13.603,F,0.03,0.003,gamb_colu,gambiae,False,True,True,False
+VBS02022-4431STDY6672890,2374,AG1000G-CM-B,Cameroon,Guijiba,2005,-1,8.476,13.644,F,0.028,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02023-4431STDY6672891,2387,AG1000G-CM-B,Cameroon,Djaba,2005,-1,8.394,13.714,F,0.032,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02024-4431STDY6672892,2396,AG1000G-CM-B,Cameroon,Djaba,2005,-1,8.394,13.714,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02025-4431STDY6672893,2466,AG1000G-CM-B,Cameroon,Banda,2005,-1,8.199,13.641,F,0.017,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02026-4431STDY6672894,2543,AG1000G-CM-B,Cameroon,Ngaouya Nga,2005,-1,7.902,13.607,F,0.017,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02027-4431STDY6672895,2608,AG1000G-CM-B,Cameroon,Djet,2005,-1,7.82,13.581,F,0.019,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02028-4431STDY6672896,2613,AG1000G-CM-B,Cameroon,Djet,2005,-1,7.82,13.581,F,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02029-4431STDY6672897,2678,AG1000G-CM-B,Cameroon,Harr,2005,-1,7.783,13.547,F,0.014,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02030-4431STDY6672898,2854,AG1000G-CM-B,Cameroon,Bini,2005,-1,7.399,13.551,F,0.032,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02031-4431STDY6672899,2879,AG1000G-CM-B,Cameroon,Gada Mabanga,2005,-1,7.354,13.578,F,0.02,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02032-4431STDY6672900,2916,AG1000G-CM-B,Cameroon,Mayo Djarani,2005,-1,7.3,13.554,F,0.033,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02033-4431STDY6672901,2931,AG1000G-CM-B,Cameroon,Mayo Djarani,2005,-1,7.3,13.554,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02034-4431STDY6672902,2945,AG1000G-CM-B,Cameroon,Mawara,2005,-1,7.335,13.462,F,0.019,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02035-4431STDY6672903,2949,AG1000G-CM-B,Cameroon,Mawara,2005,-1,7.335,13.462,F,0.028,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02036-4431STDY6672904,2964,AG1000G-CM-B,Cameroon,Toumbouroum,2005,-1,7.323,13.4,F,0.015,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02037-4431STDY6672905,2973,AG1000G-CM-B,Cameroon,Toumbouroum,2005,-1,7.323,13.4,F,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02038-4431STDY6672906,3140,AG1000G-CM-B,Cameroon,Lougga Tapadi,2005,-1,7.107,13.209,F,0.028,0.002,gamb_colu,gambiae,False,True,True,False
+AN0348-C,1453,AG1000G-CM-C,Cameroon,Nkolondom,2013,10,3.972,11.516,F,0.954,0.002,gamb_colu,coluzzii,False,True,False,True
+AN0402-C,1501,AG1000G-CM-C,Cameroon,Nkolondom,2013,10,3.972,11.516,F,0.955,0.001,gamb_colu,coluzzii,False,True,False,True
+AN0325-C,321,AG1000G-CM-C,Cameroon,Tibati,2013,10,6.469,12.629,F,0.033,0.003,gamb_colu,gambiae,False,True,True,False
+AN0408-C,1460,AG1000G-CM-C,Cameroon,Nkolondom,2013,10,3.972,11.516,F,0.059,0.003,gamb_colu,gambiae,False,True,True,False
+AN0344-C,1295,AG1000G-CM-C,Cameroon,Yaounde,2013,10,3.88,11.506,F,0.945,0.002,gamb_colu,coluzzii,False,True,False,True
+AN0326-C,336,AG1000G-CM-C,Cameroon,Tibati,2013,10,6.469,12.629,F,0.038,0.003,gamb_colu,gambiae,False,True,True,False
+AN0341-C,621,AG1000G-CM-C,Cameroon,Lagdo,2013,10,9.049,13.656,F,0.478,0.651,arabiensis,,True,False,False,False
+AN0338-C,557,AG1000G-CM-C,Cameroon,Lagdo,2013,10,9.049,13.656,F,0.493,0.618,arabiensis,,True,False,False,False
+AN0379-C,362,AG1000G-CM-C,Cameroon,Tibati,2013,10,6.469,12.629,F,0.943,0.007,gamb_colu,coluzzii,False,True,False,True
+AN0332-C,489,AG1000G-CM-C,Cameroon,Tibati,2013,10,6.469,12.629,F,0.965,0.006,gamb_colu,coluzzii,False,True,False,True
+AN0585-CW,1253,AG1000G-CM-C,Cameroon,Manda,2013,10,5.726,10.868,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AN0577-CW,1240,AG1000G-CM-C,Cameroon,Manda,2013,10,5.726,10.868,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AN0586-CW,1254,AG1000G-CM-C,Cameroon,Manda,2013,10,5.726,10.868,F,0.032,0.002,gamb_colu,gambiae,False,True,True,False
+AN0601-CW,1305,AG1000G-CM-C,Cameroon,Yaounde,2013,10,3.88,11.506,F,0.947,0.002,gamb_colu,coluzzii,False,True,False,True
+AN0616-CW,1214,AG1000G-CM-C,Cameroon,Yaounde,2013,10,3.88,11.506,F,0.952,0.001,gamb_colu,coluzzii,False,True,False,True
+AN0544-CW,630,AG1000G-CM-C,Cameroon,Lagdo,2013,10,9.049,13.656,F,0.967,0.002,gamb_colu,coluzzii,False,True,False,True
+AN0578-CW,1241,AG1000G-CM-C,Cameroon,Manda,2013,10,5.726,10.868,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AN0587-CW,1255,AG1000G-CM-C,Cameroon,Manda,2013,10,5.726,10.868,F,0.036,0.003,gamb_colu,gambiae,False,True,True,False
+AN0619-CW,1217,AG1000G-CM-C,Cameroon,Yaounde,2013,10,3.88,11.506,F,0.955,0.002,gamb_colu,coluzzii,False,True,False,True
+AN0579-CW,1246,AG1000G-CM-C,Cameroon,Manda,2013,10,5.726,10.868,F,0.035,0.004,gamb_colu,gambiae,False,True,True,False
+AN0588-CW,1361,AG1000G-CM-C,Cameroon,Manchoutvi,2013,10,5.88,11.11,F,0.027,0.003,gamb_colu,gambiae,False,True,True,False
+AN0603-CW,1307,AG1000G-CM-C,Cameroon,Yaounde,2013,10,3.88,11.506,F,0.949,0.001,gamb_colu,coluzzii,False,True,False,True
+AN0580-CW,1247,AG1000G-CM-C,Cameroon,Manda,2013,10,5.726,10.868,F,0.03,0.002,gamb_colu,gambiae,False,True,True,False
+AN0604-CW,1308,AG1000G-CM-C,Cameroon,Yaounde,2013,10,3.88,11.506,F,0.955,0.001,gamb_colu,coluzzii,False,True,False,True
+AN0581-CW,1248,AG1000G-CM-C,Cameroon,Manda,2013,10,5.726,10.868,F,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+AN0590-CW,1143,AG1000G-CM-C,Cameroon,Douala,2013,10,4.055,9.721,F,0.946,0.001,gamb_colu,coluzzii,False,True,False,True
+AN0574-CW,944,AG1000G-CM-C,Cameroon,Afan-Essokye,2013,10,2.367,9.983,F,0.036,0.002,gamb_colu,gambiae,False,True,True,False
+AN0582-CW,1250,AG1000G-CM-C,Cameroon,Manda,2013,10,5.726,10.868,F,0.025,0.003,gamb_colu,gambiae,False,True,True,False
+AN0607-CW,1408,AG1000G-CM-C,Cameroon,Yaounde,2013,10,3.88,11.506,F,0.955,0.001,gamb_colu,coluzzii,False,True,False,True
+AN0626-CW,1493,AG1000G-CM-C,Cameroon,Nkolondom,2013,10,3.972,11.516,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AN0398-CW,1499,AG1000G-CM-C,Cameroon,Nkolondom,2013,10,3.972,11.516,F,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+AN0621-CW,1471,AG1000G-CM-C,Cameroon,Nkolondom,2013,10,3.972,11.516,F,0.948,0.001,gamb_colu,coluzzii,False,True,False,True
+AN0405-CW,1492,AG1000G-CM-C,Cameroon,Nkolondom,2013,10,3.972,11.516,F,0.031,0.002,gamb_colu,gambiae,False,True,True,False
+AN0622-CW,1486,AG1000G-CM-C,Cameroon,Nkolondom,2013,10,3.972,11.516,F,0.963,0.001,gamb_colu,coluzzii,False,True,False,True
+AN0633-CW,911,AG1000G-CM-C,Cameroon,Campo,2013,10,2.367,9.817,F,0.934,0.001,gamb_colu,coluzzii,False,True,False,True
+AN0623-CW,1487,AG1000G-CM-C,Cameroon,Nkolondom,2013,10,3.972,11.516,F,0.963,0.001,gamb_colu,coluzzii,False,True,False,True
+AN0634-CW,908,AG1000G-CM-C,Cameroon,Campo,2013,10,2.367,9.817,F,0.943,0.001,gamb_colu,coluzzii,False,True,False,True
+AN0624-CW,1498,AG1000G-CM-C,Cameroon,Nkolondom,2013,10,3.972,11.516,F,0.032,0.002,gamb_colu,gambiae,False,True,True,False
+AN0643-CW,1379,AG1000G-CM-C,Cameroon,Manchoutvi,2013,10,5.88,11.11,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AN0495-CW,185,AG1000G-CM-C,Cameroon,Mgbandji,2013,10,6.097,11.141,F,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+AN0499-CW,1232,AG1000G-CM-C,Cameroon,Mfelap,2013,10,5.726,10.868,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AN0500-CW,1242,AG1000G-CM-C,Cameroon,Manda,2013,10,5.726,10.868,F,0.032,0.002,gamb_colu,gambiae,False,True,True,False
+AN0503-CW,1245,AG1000G-CM-C,Cameroon,Manda,2013,10,5.726,10.868,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AN0511-CW,1090,AG1000G-CM-C,Cameroon,Douala,2013,10,4.055,9.721,F,0.96,0.001,gamb_colu,coluzzii,False,True,False,True
+AP0007-C,60,AG1000G-FR,Mayotte,Mtsamboro Forest Reserve,2011,-1,-12.703,45.081,F,0.035,0.003,gamb_colu,gambiae,False,True,True,False
+AP0021-C,92,AG1000G-FR,Mayotte,Karihani Lake,2011,-1,-12.797,45.122,F,0.034,0.003,gamb_colu,gambiae,False,True,True,False
+AP0019-C,88,AG1000G-FR,Mayotte,Mtsanga Charifou,2011,-1,-12.991,45.156,M,0.039,0.003,gamb_colu,gambiae,False,True,True,False
+AP0020-C,78,AG1000G-FR,Mayotte,Mtsanga Charifou,2011,-1,-12.991,45.156,M,0.039,0.003,gamb_colu,gambiae,False,True,True,False
+AP0009-C,62,AG1000G-FR,Mayotte,Combani,2011,-1,-12.779,45.143,M,0.038,0.003,gamb_colu,gambiae,False,True,True,False
+AP0002-C,64,AG1000G-FR,Mayotte,Combani,2011,-1,-12.779,45.143,F,0.027,0.003,gamb_colu,gambiae,False,True,True,False
+AP0034-C,97,AG1000G-FR,Mayotte,Sada,2011,-1,-12.852,45.104,M,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AP0035-C,99,AG1000G-FR,Mayotte,Sada,2011,-1,-12.852,45.104,M,0.043,0.003,gamb_colu,gambiae,False,True,True,False
+AP0031-C,80,AG1000G-FR,Mayotte,Mtsanga Charifou,2011,-1,-12.991,45.156,M,0.038,0.002,gamb_colu,gambiae,False,True,True,False
+AP0008-C,61,AG1000G-FR,Mayotte,Combani,2011,-1,-12.779,45.143,F,0.031,0.003,gamb_colu,gambiae,False,True,True,False
+AP0011-C,65,AG1000G-FR,Mayotte,Combani,2011,-1,-12.779,45.143,M,0.037,0.003,gamb_colu,gambiae,False,True,True,False
+AP0032-C,89,AG1000G-FR,Mayotte,Mtsanga Charifou,2011,-1,-12.991,45.156,M,0.031,0.003,gamb_colu,gambiae,False,True,True,False
+AP0010-C,63,AG1000G-FR,Mayotte,Combani,2011,-1,-12.779,45.143,M,0.035,0.003,gamb_colu,gambiae,False,True,True,False
+AP0025-C,100,AG1000G-FR,Mayotte,Sada,2011,-1,-12.852,45.104,M,0.031,0.003,gamb_colu,gambiae,False,True,True,False
+AP0022-C,94,AG1000G-FR,Mayotte,Karihani Lake,2011,-1,-12.797,45.122,F,0.028,0.002,gamb_colu,gambiae,False,True,True,False
+AP0006-C,77,AG1000G-FR,Mayotte,Mtsanga Charifou,2011,-1,-12.991,45.156,F,0.035,0.003,gamb_colu,gambiae,False,True,True,False
+AP0030-C,76,AG1000G-FR,Mayotte,Mont Benara,2011,-1,-12.857,45.155,F,0.037,0.002,gamb_colu,gambiae,False,True,True,False
+AP0023-C,79,AG1000G-FR,Mayotte,Mtsanga Charifou,2011,-1,-12.991,45.156,F,0.036,0.003,gamb_colu,gambiae,False,True,True,False
+AP0033-C,95,AG1000G-FR,Mayotte,Karihani Lake,2011,-1,-12.797,45.122,F,0.04,0.002,gamb_colu,gambiae,False,True,True,False
+AP0005-C,38,AG1000G-FR,Mayotte,Bouyouni,2011,-1,-12.738,45.142,F,0.034,0.003,gamb_colu,gambiae,False,True,True,False
+AP0014-Cx,72,AG1000G-FR,Mayotte,Mont Benara,2011,-1,-12.857,45.155,M,0.035,0.003,gamb_colu,gambiae,False,True,True,False
+AP0013-Cx,68,AG1000G-FR,Mayotte,Combani,2011,-1,-12.779,45.143,M,0.036,0.003,gamb_colu,gambiae,False,True,True,False
+AP0017-Cx,81,AG1000G-FR,Mayotte,Mtsanga Charifou,2011,-1,-12.991,45.156,F,0.028,0.003,gamb_colu,gambiae,False,True,True,False
+AS0001-C,LIB001,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.042,0.001,gamb_colu,gambiae,False,True,True,False
+AS0002-Cx,LIB002,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AS0003-C,LIB003,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.034,0.002,gamb_colu,gambiae,False,True,True,False
+AS0004-C,LIB004,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.031,0.002,gamb_colu,gambiae,False,True,True,False
+AS0005-C,LIB005,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AS0006-C,LIB006,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.071,0.002,gamb_colu,gambiae,False,True,True,False
+AS0007-C,LIB007,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.045,0.002,gamb_colu,gambiae,False,True,True,False
+AS0008-Cx,LIB008,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.028,0.001,gamb_colu,gambiae,False,True,True,False
+AS0009-C,LIB009,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.044,0.002,gamb_colu,gambiae,False,True,True,False
+AS0010-C,LIB010,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.035,0.002,gamb_colu,gambiae,False,True,True,False
+AS0011-C,LIB011,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.069,0.002,gamb_colu,gambiae,False,True,True,False
+AS0012-C,LIB012,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AS0013-C,LIB013,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.09,0.001,gamb_colu,gambiae,False,True,True,False
+AS0014-Cx,LIB014,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.039,0.002,gamb_colu,gambiae,False,True,True,False
+AS0015-Cx,LIB015,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.068,0.002,gamb_colu,gambiae,False,True,True,False
+AS0016-C,LIB016,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AS0017-C,LIB017,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.038,0.001,gamb_colu,gambiae,False,True,True,False
+AS0018-C,LIB018,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+AS0019-Cx,LIB019,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.042,0.002,gamb_colu,gambiae,False,True,True,False
+AS0020-C,LIB020,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.036,0.002,gamb_colu,gambiae,False,True,True,False
+AS0021-C,LIB021,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.069,0.002,gamb_colu,gambiae,False,True,True,False
+AS0022-C,LIB022,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.081,0.002,gamb_colu,gambiae,False,True,True,False
+AS0023-Cx,LIB023,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.07,0.002,gamb_colu,gambiae,False,True,True,False
+AS0024-Cx,LIB024,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.039,0.002,gamb_colu,gambiae,False,True,True,False
+AS0026-C,LIB026,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.033,0.002,gamb_colu,gambiae,False,True,True,False
+AS0027-Cx,LIB027,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AS0028-C,LIB028,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.032,0.002,gamb_colu,gambiae,False,True,True,False
+AS0029-C,LIB029,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.036,0.002,gamb_colu,gambiae,False,True,True,False
+AS0030-C,LIB030,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AS0032-C,LIB032,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.039,0.001,gamb_colu,gambiae,False,True,True,False
+AS0033-C,LIB033,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+AS0034-C,LIB034,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.072,0.002,gamb_colu,gambiae,False,True,True,False
+AS0035-Cx,LIB035,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.039,0.002,gamb_colu,gambiae,False,True,True,False
+AS0036-C,LIB036,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.037,0.001,gamb_colu,gambiae,False,True,True,False
+AS0037-C,LIB037,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.067,0.002,gamb_colu,gambiae,False,True,True,False
+AS0039-C,LIB039,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.027,0.001,gamb_colu,gambiae,False,True,True,False
+AS0040-C,LIB040,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.035,0.002,gamb_colu,gambiae,False,True,True,False
+AS0041-C,LIB041,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AS0042-C,LIB042,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.055,0.002,gamb_colu,gambiae,False,True,True,False
+AS0044-Cx,LIB044,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AS0045-Cx,LIB045,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.028,0.002,gamb_colu,gambiae,False,True,True,False
+AS0046-C,LIB046,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.039,0.002,gamb_colu,gambiae,False,True,True,False
+AS0047-C,LIB047,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AS0048-C,LIB048,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.075,0.002,gamb_colu,gambiae,False,True,True,False
+AS0049-C,LIB049,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AS0051-C,LIB051,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.029,0.001,gamb_colu,gambiae,False,True,True,False
+AS0052-C,LIB052,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.037,0.001,gamb_colu,gambiae,False,True,True,False
+AS0053-C,LIB053,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.04,0.002,gamb_colu,gambiae,False,True,True,False
+AS0054-C,LIB054,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.053,0.002,gamb_colu,gambiae,False,True,True,False
+AS0055-C,LIB055,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.067,0.002,gamb_colu,gambiae,False,True,True,False
+AS0056-C,LIB056,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.032,0.002,gamb_colu,gambiae,False,True,True,False
+AS0057-C,LIB057,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.075,0.001,gamb_colu,gambiae,False,True,True,False
+AS0058-Cx,LIB058,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.076,0.002,gamb_colu,gambiae,False,True,True,False
+AS0059-C,LIB059,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.035,0.002,gamb_colu,gambiae,False,True,True,False
+AS0060-C,LIB060,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.039,0.002,gamb_colu,gambiae,False,True,True,False
+AS0062-C,LIB062,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.044,0.002,gamb_colu,gambiae,False,True,True,False
+AS0064-C,LIB064,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.033,0.002,gamb_colu,gambiae,False,True,True,False
+AS0065-C,LIB065,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.037,0.002,gamb_colu,gambiae,False,True,True,False
+AS0066-C,LIB066,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.03,0.002,gamb_colu,gambiae,False,True,True,False
+AS0068-C,LIB068,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AS0069-C,LIB069,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AS0070-C,LIB070,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AS0071-C,LIB071,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.035,0.002,gamb_colu,gambiae,False,True,True,False
+AS0072-Cx,LIB072,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.079,0.002,gamb_colu,gambiae,False,True,True,False
+AS0073-C,LIB073,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.071,0.002,gamb_colu,gambiae,False,True,True,False
+AS0074-C,LIB074,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.04,0.002,gamb_colu,gambiae,False,True,True,False
+AS0076-C,LIB076,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.069,0.001,gamb_colu,gambiae,False,True,True,False
+AS0077-C,LIB077,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.047,0.002,gamb_colu,gambiae,False,True,True,False
+AS0078-C,LIB078,AG1000G-GA-A,Gabon,Libreville,2000,12,0.384,9.455,F,0.037,0.002,gamb_colu,gambiae,False,True,True,False
+AA0052-C,Twifo_Praso__F2,AG1000G-GH,Ghana,Twifo Praso,2012,9,5.609,-1.549,F,0.97,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0103-C,Takoradi_H9,AG1000G-GH,Ghana,Takoradi,2012,8,4.912,-1.774,F,0.967,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0115-C,Takoradi_A10,AG1000G-GH,Ghana,Takoradi,2012,8,4.912,-1.774,F,0.967,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0050-C,Madina_E5,AG1000G-GH,Ghana,Madina,2012,11,5.668,-0.219,F,0.057,0.002,gamb_colu,gambiae,False,True,True,False
+AA0134-C,Madina_D6,AG1000G-GH,Ghana,Madina,2012,11,5.668,-0.219,F,0.972,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0063-C,Twifo_Praso__D1,AG1000G-GH,Ghana,Twifo Praso,2012,9,5.609,-1.549,F,0.972,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0040-C,Twifo_Praso__E2,AG1000G-GH,Ghana,Twifo Praso,2012,9,5.609,-1.549,F,0.979,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0064-C,Twifo_Praso__G2,AG1000G-GH,Ghana,Twifo Praso,2012,9,5.609,-1.549,F,0.971,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0088-C,Twifo_Praso__C3,AG1000G-GH,Ghana,Twifo Praso,2012,9,5.609,-1.549,F,0.98,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0100-C,Twifo_Praso__E3,AG1000G-GH,Ghana,Twifo Praso,2012,9,5.609,-1.549,F,0.968,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0077-C,Twifo_Praso__C4,AG1000G-GH,Ghana,Twifo Praso,2012,9,5.609,-1.549,F,0.977,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0055-C,Takoradi_B9,AG1000G-GH,Ghana,Takoradi,2012,8,4.912,-1.774,F,0.977,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0116-C,Takoradi_F11,AG1000G-GH,Ghana,Takoradi,2012,8,4.912,-1.774,F,0.978,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0059-C,Koforidua_F5,AG1000G-GH,Ghana,Koforidua,2012,11,6.094,-0.261,F,0.057,0.002,gamb_colu,gambiae,False,True,True,False
+AA0084-C,Madina_A2,AG1000G-GH,Ghana,Madina,2012,11,5.668,-0.219,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AA0066-C,Takoradi_G7,AG1000G-GH,Ghana,Takoradi,2012,8,4.912,-1.774,F,0.965,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0106-C,Koforidua_G4,AG1000G-GH,Ghana,Koforidua,2012,11,6.094,-0.261,F,0.036,0.002,gamb_colu,gambiae,False,True,True,False
+AA0107-C,Koforidua_D6,AG1000G-GH,Ghana,Koforidua,2012,11,6.094,-0.261,F,0.975,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0060-C,Madina_C1,AG1000G-GH,Ghana,Madina,2012,11,5.668,-0.219,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AA0051-C,Twifo_Praso__C1,AG1000G-GH,Ghana,Twifo Praso,2012,9,5.609,-1.549,F,0.971,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0087-C,Twifo_Praso__H1,AG1000G-GH,Ghana,Twifo Praso,2012,9,5.609,-1.549,F,0.977,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0065-C,Twifo_Praso__B4,AG1000G-GH,Ghana,Twifo Praso,2012,9,5.609,-1.549,F,0.975,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0125-C,Twifo_Praso__A5,AG1000G-GH,Ghana,Twifo Praso,2012,9,5.609,-1.549,F,0.972,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0104-C,Takoradi_E11,AG1000G-GH,Ghana,Takoradi,2012,8,4.912,-1.774,F,0.97,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0119-C,Koforidua_E6,AG1000G-GH,Ghana,Koforidua,2012,11,6.094,-0.261,F,0.02,0.002,gamb_colu,gambiae,False,True,True,False
+AA0061-C,Madina_F3,AG1000G-GH,Ghana,Madina,2012,11,5.668,-0.219,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AA0098-C,Madina_A6,AG1000G-GH,Ghana,Madina,2012,11,5.668,-0.219,F,0.976,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0112-C,Twifo_Praso__F3,AG1000G-GH,Ghana,Twifo Praso,2012,9,5.609,-1.549,F,0.961,0.003,gamb_colu,coluzzii,False,True,False,True
+AA0089-C,Twifo_Praso__D4,AG1000G-GH,Ghana,Twifo Praso,2012,9,5.609,-1.549,F,0.963,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0101-C,Twifo_Praso__E4,AG1000G-GH,Ghana,Twifo Praso,2012,9,5.609,-1.549,F,0.961,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0113-C,Twifo_Praso__H4,AG1000G-GH,Ghana,Twifo Praso,2012,9,5.609,-1.549,F,0.964,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0044-C,Takoradi_D10,AG1000G-GH,Ghana,Takoradi,2012,8,4.912,-1.774,F,0.972,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0105-C,Koforidua_D3,AG1000G-GH,Ghana,Koforidua,2012,11,6.094,-0.261,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AA0070-C,Koforidua_B4,AG1000G-GH,Ghana,Koforidua,2012,11,6.094,-0.261,F,0.019,0.002,gamb_colu,gambiae,False,True,True,False
+AA0075-C,Twifo_Praso__F1,AG1000G-GH,Ghana,Twifo Praso,2012,9,5.609,-1.549,F,0.972,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0041-C,Twifo_Praso__H3,AG1000G-GH,Ghana,Twifo Praso,2012,9,5.609,-1.549,F,0.973,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0042-C,Takoradi_C7,AG1000G-GH,Ghana,Takoradi,2012,8,4.912,-1.774,F,0.974,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0114-C,Takoradi_F8,AG1000G-GH,Ghana,Takoradi,2012,8,4.912,-1.774,F,0.977,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0126-C,Takoradi_G8,AG1000G-GH,Ghana,Takoradi,2012,8,4.912,-1.774,F,0.955,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0093-C,Koforidua_C3,AG1000G-GH,Ghana,Koforidua,2012,11,6.094,-0.261,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AA0123-C,Twifo_Praso__D2,AG1000G-GH,Ghana,Twifo Praso,2012,9,5.609,-1.549,F,0.968,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0054-C,Takoradi_E7,AG1000G-GH,Ghana,Takoradi,2012,8,4.912,-1.774,F,0.975,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0128-C,Takoradi_H11,AG1000G-GH,Ghana,Takoradi,2012,8,4.912,-1.774,F,0.976,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0129-C,Koforidua_F3,AG1000G-GH,Ghana,Koforidua,2012,11,6.094,-0.261,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AA0094-C,Koforidua_E4,AG1000G-GH,Ghana,Koforidua,2012,11,6.094,-0.261,F,0.058,0.002,gamb_colu,gambiae,False,True,True,False
+AA0118-C,Koforidua_B5,AG1000G-GH,Ghana,Koforidua,2012,11,6.094,-0.261,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AA0071-C,Koforidua_G5,AG1000G-GH,Ghana,Koforidua,2012,11,6.094,-0.261,F,0.064,0.002,gamb_colu,gambiae,False,True,True,False
+AA0097-C,Madina_E4,AG1000G-GH,Ghana,Madina,2012,11,5.668,-0.219,F,0.981,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0092-C,Takoradi_C11,AG1000G-GH,Ghana,Takoradi,2012,8,4.912,-1.774,F,0.974,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0047-C,Koforidua_D5,AG1000G-GH,Ghana,Koforidua,2012,11,6.094,-0.261,F,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+AA0141-C,Madina_H6,AG1000G-GH,Ghana,Madina,2012,11,5.668,-0.219,F,0.964,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0039-C,Twifo_Praso__B1,AG1000G-GH,Ghana,Twifo Praso,2012,9,5.609,-1.549,F,0.977,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0046-C,Koforidua_G3,AG1000G-GH,Ghana,Koforidua,2012,11,6.094,-0.261,F,0.028,0.002,gamb_colu,gambiae,False,True,True,False
+AA0095-C,Koforidua_C6,AG1000G-GH,Ghana,Koforidua,2012,11,6.094,-0.261,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AA0120-C,Madina_C3,AG1000G-GH,Ghana,Madina,2012,11,5.668,-0.219,F,0.964,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0076-C,Twifo_Praso__B3,AG1000G-GH,Ghana,Twifo Praso,2012,9,5.609,-1.549,F,0.977,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0043-C,Takoradi_H8,AG1000G-GH,Ghana,Takoradi,2012,8,4.912,-1.774,F,0.968,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0127-C,Takoradi_C10,AG1000G-GH,Ghana,Takoradi,2012,8,4.912,-1.774,F,0.968,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0069-C,Koforidua_F2,AG1000G-GH,Ghana,Koforidua,2012,11,6.094,-0.261,F,0.019,0.002,gamb_colu,gambiae,False,True,True,False
+AA0049-C,Madina_E3,AG1000G-GH,Ghana,Madina,2012,11,5.668,-0.219,F,0.968,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0133-C,Madina_B5,AG1000G-GH,Ghana,Madina,2012,11,5.668,-0.219,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AA0110-C,Madina_B6,AG1000G-GH,Ghana,Madina,2012,11,5.668,-0.219,F,0.968,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0099-C,Twifo_Praso__A2,AG1000G-GH,Ghana,Twifo Praso,2012,9,5.609,-1.549,F,0.968,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0111-C,Twifo_Praso__B2,AG1000G-GH,Ghana,Twifo Praso,2012,9,5.609,-1.549,F,0.978,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0090-C,Takoradi_D8,AG1000G-GH,Ghana,Takoradi,2012,8,4.912,-1.774,F,0.978,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0067-C,Takoradi_C9,AG1000G-GH,Ghana,Takoradi,2012,8,4.912,-1.774,F,0.974,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0117-C,Koforidua_E3,AG1000G-GH,Ghana,Koforidua,2012,11,6.094,-0.261,F,0.03,0.002,gamb_colu,gambiae,False,True,True,False
+AA0131-C,Koforidua_F6,AG1000G-GH,Ghana,Koforidua,2012,11,6.094,-0.261,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AA0096-C,Madina_H2,AG1000G-GH,Ghana,Madina,2012,11,5.668,-0.219,F,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+AA0053-C,Twifo_Praso__A4,AG1000G-GH,Ghana,Twifo Praso,2012,9,5.609,-1.549,F,0.968,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0102-C,Takoradi_E8,AG1000G-GH,Ghana,Takoradi,2012,8,4.912,-1.774,F,0.965,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0130-C,Koforidua_C5,AG1000G-GH,Ghana,Koforidua,2012,11,6.094,-0.261,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AA0132-C,Madina_D3,AG1000G-GH,Ghana,Madina,2012,11,5.668,-0.219,F,0.966,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0085-C,Madina_A4,AG1000G-GH,Ghana,Madina,2012,11,5.668,-0.219,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AA0048-C,Madina_A1,AG1000G-GH,Ghana,Madina,2012,11,5.668,-0.219,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AA0056-C,Takoradi_G10,AG1000G-GH,Ghana,Takoradi,2012,8,4.912,-1.774,F,0.971,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0068-C,Takoradi_H10,AG1000G-GH,Ghana,Takoradi,2012,8,4.912,-1.774,F,0.974,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0058-C,Koforidua_A4,AG1000G-GH,Ghana,Koforidua,2012,11,6.094,-0.261,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AA0073-C,Madina_H3,AG1000G-GH,Ghana,Madina,2012,11,5.668,-0.219,F,0.966,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0062-C,Madina_F5,AG1000G-GH,Ghana,Madina,2012,11,5.668,-0.219,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AA0074-C,Madina_G5,AG1000G-GH,Ghana,Madina,2012,11,5.668,-0.219,F,0.968,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0138-C,Madina_E6,AG1000G-GH,Ghana,Madina,2012,11,5.668,-0.219,F,0.975,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0091-C,Takoradi_G9,AG1000G-GH,Ghana,Takoradi,2012,8,4.912,-1.774,F,0.96,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0081-C,Koforidua_G2,AG1000G-GH,Ghana,Koforidua,2012,11,6.094,-0.261,F,0.02,0.002,gamb_colu,gambiae,False,True,True,False
+AA0082-C,Koforidua_D4,AG1000G-GH,Ghana,Koforidua,2012,11,6.094,-0.261,F,0.065,0.002,gamb_colu,gambiae,False,True,True,False
+AA0109-C,Madina_F4,AG1000G-GH,Ghana,Madina,2012,11,5.668,-0.219,F,0.967,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0122-C,Madina_C6,AG1000G-GH,Ghana,Madina,2012,11,5.668,-0.219,F,0.016,0.002,gamb_colu,gambiae,False,True,True,False
+AA0137-C,Koforidua_G6,AG1000G-GH,Ghana,Koforidua,2012,11,6.094,-0.261,F,0.03,0.002,gamb_colu,gambiae,False,True,True,False
+AA0140-C,Madina_G6,AG1000G-GH,Ghana,Madina,2012,11,5.668,-0.219,F,0.975,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0079-C,Takoradi_F9,AG1000G-GH,Ghana,Takoradi,2012,8,4.912,-1.774,F,0.974,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0080-C,Takoradi_A11,AG1000G-GH,Ghana,Takoradi,2012,8,4.912,-1.774,F,0.97,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0086-C,Madina_H5,AG1000G-GH,Ghana,Madina,2012,11,5.668,-0.219,F,0.031,0.002,gamb_colu,gambiae,False,True,True,False
+AA0136-C,Takoradi_A12,AG1000G-GH,Ghana,Takoradi,2012,8,4.912,-1.774,F,0.965,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0139-C,Madina_F6,AG1000G-GH,Ghana,Madina,2012,11,5.668,-0.219,F,0.975,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0057-C,Koforidua_D2,AG1000G-GH,Ghana,Koforidua,2012,11,6.094,-0.261,F,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+AA0135-C,Twifo_Praso__C5,AG1000G-GH,Ghana,Twifo Praso,2012,9,5.609,-1.549,F,0.966,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0124-C,Twifo_Praso__G3,AG1000G-GH,Ghana,Twifo Praso,2012,9,5.609,-1.549,F,0.979,0.002,gamb_colu,coluzzii,False,True,False,True
+AA0045-C,Koforidua_A2,AG1000G-GH,Ghana,Koforidua,2012,11,6.094,-0.261,F,0.035,0.002,gamb_colu,gambiae,False,True,True,False
+AA0072-C,Madina_F1,AG1000G-GH,Ghana,Madina,2012,11,5.668,-0.219,F,0.02,0.002,gamb_colu,gambiae,False,True,True,False
+AA0108-C,Madina_A3,AG1000G-GH,Ghana,Madina,2012,11,5.668,-0.219,F,0.068,0.002,gamb_colu,gambiae,False,True,True,False
+AG0147-C,2614,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.152,0.005,gamb_colu,intermediate,False,True,False,False
+AG0159-C,2626,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.076,0.005,gamb_colu,gambiae,False,True,True,False
+AG0232-C,2761,AG1000G-GM-A,The Gambia,Njabakunda,2011,10,13.55,-15.9,F,0.107,0.005,gamb_colu,gambiae,False,True,True,False
+AG0129-C,2596,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.077,0.005,gamb_colu,gambiae,False,True,True,False
+AG0153-C,2620,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.097,0.005,gamb_colu,gambiae,False,True,True,False
+AG0163-C,2630,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.087,0.005,gamb_colu,gambiae,False,True,True,False
+AG0200-C,2698,AG1000G-GM-A,The Gambia,Njabakunda,2011,10,13.55,-15.9,F,0.948,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0209-C,2707,AG1000G-GM-A,The Gambia,Njabakunda,2011,10,13.55,-15.9,F,0.928,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0229-C,2758,AG1000G-GM-A,The Gambia,Njabakunda,2011,10,13.55,-15.9,F,0.079,0.005,gamb_colu,gambiae,False,True,True,False
+AG0230-C,2759,AG1000G-GM-A,The Gambia,Njabakunda,2011,10,13.55,-15.9,F,0.11,0.004,gamb_colu,gambiae,False,True,True,False
+AG0098-C,2534,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.08,0.005,gamb_colu,gambiae,False,True,True,False
+AG0104-C,2540,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.077,0.005,gamb_colu,gambiae,False,True,True,False
+AG0106-C,2542,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.073,0.006,gamb_colu,gambiae,False,True,True,False
+AG0120-C,2556,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.118,0.005,gamb_colu,gambiae,False,True,True,False
+AG0136-C,2603,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.078,0.004,gamb_colu,gambiae,False,True,True,False
+AG0141-C,2608,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.102,0.005,gamb_colu,gambiae,False,True,True,False
+AG0145-C,2612,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.07,0.005,gamb_colu,gambiae,False,True,True,False
+AG0148-C,2615,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.082,0.004,gamb_colu,gambiae,False,True,True,False
+AG0172-C,2639,AG1000G-GM-A,The Gambia,Njabakunda,2011,9,13.55,-15.9,F,0.12,0.007,gamb_colu,gambiae,False,True,True,False
+AG0179-C,2677,AG1000G-GM-A,The Gambia,Njabakunda,2011,9,13.55,-15.9,F,0.08,0.006,gamb_colu,gambiae,False,True,True,False
+AG0223-C,2721,AG1000G-GM-A,The Gambia,Njabakunda,2011,10,13.55,-15.9,F,0.075,0.005,gamb_colu,gambiae,False,True,True,False
+AG0118-C,2554,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.133,0.006,gamb_colu,intermediate,False,True,False,False
+AG0119-C,2555,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.077,0.004,gamb_colu,gambiae,False,True,True,False
+AG0121-C,2557,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.104,0.005,gamb_colu,gambiae,False,True,True,False
+AG0133-C,2600,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.061,0.004,gamb_colu,gambiae,False,True,True,False
+AG0134-C,2601,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.08,0.004,gamb_colu,gambiae,False,True,True,False
+AG0138-C,2605,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.078,0.004,gamb_colu,gambiae,False,True,True,False
+AG0227-C,2725,AG1000G-GM-A,The Gambia,Njabakunda,2011,10,13.55,-15.9,F,0.12,0.005,gamb_colu,intermediate,False,True,False,False
+AG0231-C,2760,AG1000G-GM-A,The Gambia,Njabakunda,2011,10,13.55,-15.9,F,0.094,0.005,gamb_colu,gambiae,False,True,True,False
+AG0102-C,2538,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.084,0.006,gamb_colu,gambiae,False,True,True,False
+AG0108-C,2544,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.098,0.006,gamb_colu,gambiae,False,True,True,False
+AG0123-C,2559,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.087,0.004,gamb_colu,gambiae,False,True,True,False
+AG0128-C,2595,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.077,0.006,gamb_colu,gambiae,False,True,True,False
+AG0137-C,2604,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.101,0.005,gamb_colu,gambiae,False,True,True,False
+AG0139-C,2606,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.087,0.004,gamb_colu,gambiae,False,True,True,False
+AG0143-C,2610,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.096,0.005,gamb_colu,gambiae,False,True,True,False
+AG0162-C,2629,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.094,0.006,gamb_colu,gambiae,False,True,True,False
+AG0170-C,2637,AG1000G-GM-A,The Gambia,Njabakunda,2011,9,13.55,-15.9,F,0.11,0.004,gamb_colu,gambiae,False,True,True,False
+AG0181-C,2679,AG1000G-GM-A,The Gambia,Njabakunda,2011,9,13.55,-15.9,F,0.127,0.006,gamb_colu,intermediate,False,True,False,False
+AG0085-C,2521,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.089,0.005,gamb_colu,gambiae,False,True,True,False
+AG0096-C,2532,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.117,0.006,gamb_colu,gambiae,False,True,True,False
+AG0126-C,2562,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.104,0.005,gamb_colu,gambiae,False,True,True,False
+AG0152-C,2619,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.088,0.005,gamb_colu,gambiae,False,True,True,False
+AG0183-C,2681,AG1000G-GM-A,The Gambia,Njabakunda,2011,9,13.55,-15.9,F,0.105,0.005,gamb_colu,gambiae,False,True,True,False
+AG0208-C,2706,AG1000G-GM-A,The Gambia,Njabakunda,2011,10,13.55,-15.9,F,0.061,0.005,gamb_colu,gambiae,False,True,True,False
+AG0214-C,2712,AG1000G-GM-A,The Gambia,Njabakunda,2011,10,13.55,-15.9,F,0.281,0.004,gamb_colu,intermediate,False,True,False,False
+AG0226-C,2724,AG1000G-GM-A,The Gambia,Njabakunda,2011,10,13.55,-15.9,F,0.119,0.004,gamb_colu,gambiae,False,True,True,False
+AG0127-C,2563,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.135,0.005,gamb_colu,intermediate,False,True,False,False
+AG0130-C,2597,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.924,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0135-C,2602,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.917,0.006,gamb_colu,coluzzii,False,True,False,True
+AG0144-C,2611,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.07,0.005,gamb_colu,gambiae,False,True,True,False
+AG0156-C,2623,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.096,0.005,gamb_colu,gambiae,False,True,True,False
+AG0206-C,2704,AG1000G-GM-A,The Gambia,Njabakunda,2011,10,13.55,-15.9,F,0.15,0.005,gamb_colu,intermediate,False,True,False,False
+AG0221-C,2719,AG1000G-GM-A,The Gambia,Njabakunda,2011,10,13.55,-15.9,F,0.101,0.005,gamb_colu,gambiae,False,True,True,False
+AG0234-C,2763,AG1000G-GM-A,The Gambia,Njabakunda,2011,10,13.55,-15.9,F,0.898,0.006,gamb_colu,intermediate,False,True,False,False
+AG0082-C,2518,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.076,0.004,gamb_colu,gambiae,False,True,True,False
+AG0097-C,2533,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.113,0.006,gamb_colu,gambiae,False,True,True,False
+AG0100-C,2536,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.124,0.005,gamb_colu,intermediate,False,True,False,False
+AG0109-C,2545,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.075,0.006,gamb_colu,gambiae,False,True,True,False
+AG0124-C,2560,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.079,0.005,gamb_colu,gambiae,False,True,True,False
+AG0142-C,2609,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.075,0.006,gamb_colu,gambiae,False,True,True,False
+AG0146-C,2613,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.061,0.004,gamb_colu,gambiae,False,True,True,False
+AG0169-C,2636,AG1000G-GM-A,The Gambia,Njabakunda,2011,9,13.55,-15.9,F,0.103,0.005,gamb_colu,gambiae,False,True,True,False
+AG0178-C,2676,AG1000G-GM-A,The Gambia,Njabakunda,2011,9,13.55,-15.9,F,0.088,0.005,gamb_colu,gambiae,False,True,True,False
+AG0195-C,2693,AG1000G-GM-A,The Gambia,Njabakunda,2011,9,13.55,-15.9,F,0.33,0.006,gamb_colu,intermediate,False,True,False,False
+AG0089-C,2525,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.064,0.005,gamb_colu,gambiae,False,True,True,False
+AG0111-C,2547,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.06,0.004,gamb_colu,gambiae,False,True,True,False
+AG0125-C,2561,AG1000G-GM-A,The Gambia,Njabakunda,2011,8,13.55,-15.9,F,0.073,0.005,gamb_colu,gambiae,False,True,True,False
+AG0197-C,2695,AG1000G-GM-A,The Gambia,Njabakunda,2011,10,13.55,-15.9,F,0.099,0.006,gamb_colu,gambiae,False,True,True,False
+AG0202-C,2700,AG1000G-GM-A,The Gambia,Njabakunda,2011,10,13.55,-15.9,F,0.087,0.004,gamb_colu,gambiae,False,True,True,False
+AG0203-C,2701,AG1000G-GM-A,The Gambia,Njabakunda,2011,10,13.55,-15.9,F,0.061,0.006,gamb_colu,gambiae,False,True,True,False
+AG0204-C,2702,AG1000G-GM-A,The Gambia,Njabakunda,2011,10,13.55,-15.9,F,0.145,0.006,gamb_colu,intermediate,False,True,False,False
+AG0225-C,2723,AG1000G-GM-A,The Gambia,Njabakunda,2011,10,13.55,-15.9,F,0.908,0.006,gamb_colu,coluzzii,False,True,False,True
+AG0263-C,2792,AG1000G-GM-A,The Gambia,Njabakunda,2011,10,13.55,-15.9,F,0.067,0.005,gamb_colu,gambiae,False,True,True,False
+AG0382-CW,001-1048,AG1000G-GM-B,The Gambia,Tankular,2012,8,13.417,-16.033,UKN,0.844,0.006,gamb_colu,intermediate,False,True,False,False
+AG0383-CW,001-1049,AG1000G-GM-B,The Gambia,Tankular,2012,8,13.417,-16.033,UKN,0.939,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0386-CW,001-1058,AG1000G-GM-B,The Gambia,Tankular,2012,8,13.417,-16.033,F,0.925,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0390-CW,001-1076,AG1000G-GM-B,The Gambia,Tankular,2012,8,13.417,-16.033,UKN,0.904,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0394-CW,001-1094,AG1000G-GM-B,The Gambia,Tankular,2012,8,13.417,-16.033,UKN,0.89,0.005,gamb_colu,intermediate,False,True,False,False
+AG0395-CW,001-1097,AG1000G-GM-B,The Gambia,Tankular,2012,8,13.417,-16.033,UKN,0.919,0.006,gamb_colu,coluzzii,False,True,False,True
+AG0396-CW,001-1100,AG1000G-GM-B,The Gambia,Tankular,2012,8,13.417,-16.033,UKN,0.916,0.006,gamb_colu,coluzzii,False,True,False,True
+AG0403-CW,001-1123,AG1000G-GM-B,The Gambia,Tankular,2012,8,13.417,-16.033,UKN,0.929,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0404-CW,001-1127,AG1000G-GM-B,The Gambia,Tankular,2012,8,13.417,-16.033,UKN,0.881,0.005,gamb_colu,intermediate,False,True,False,False
+AG0405-CW,001-1131,AG1000G-GM-B,The Gambia,Tankular,2012,8,13.417,-16.033,UKN,0.887,0.005,gamb_colu,intermediate,False,True,False,False
+AG0406-CW,001-1134,AG1000G-GM-B,The Gambia,Tankular,2012,8,13.417,-16.033,UKN,0.954,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0410-CW,001-1149,AG1000G-GM-B,The Gambia,Tankular,2012,8,13.417,-16.033,UKN,0.901,0.006,gamb_colu,coluzzii,False,True,False,True
+AG0411-CW,001-1153,AG1000G-GM-B,The Gambia,Tankular,2012,8,13.417,-16.033,UKN,0.905,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0412-CW,001-1159,AG1000G-GM-B,The Gambia,Tankular,2012,8,13.417,-16.033,UKN,0.929,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0415-CW,001-1168,AG1000G-GM-B,The Gambia,Tankular,2012,8,13.417,-16.033,UKN,0.93,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0416-CW,001-1183,AG1000G-GM-B,The Gambia,Tankular,2012,8,13.417,-16.033,UKN,0.93,0.007,gamb_colu,coluzzii,False,True,False,True
+AG0418-CW,001-1190,AG1000G-GM-B,The Gambia,Tankular,2012,8,13.417,-16.033,UKN,0.926,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0420-CW,001-1197,AG1000G-GM-B,The Gambia,Tankular,2012,8,13.417,-16.033,UKN,0.78,0.005,gamb_colu,intermediate,False,True,False,False
+AG0422-CW,001-1212,AG1000G-GM-B,The Gambia,Tankular,2012,8,13.417,-16.033,UKN,0.942,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0423-CW,002-1125,AG1000G-GM-B,The Gambia,Kalataba,2012,8,13.55,-15.617,UKN,0.918,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0442-CW,009-1006,AG1000G-GM-B,The Gambia,Sare Samba Sowe,2012,8,13.583,-15.9,UKN,0.108,0.005,gamb_colu,gambiae,False,True,True,False
+AG0443-CW,009-1010,AG1000G-GM-B,The Gambia,Sare Samba Sowe,2012,8,13.583,-15.9,UKN,0.949,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0445-CW,009-1014,AG1000G-GM-B,The Gambia,Sare Samba Sowe,2012,8,13.583,-15.9,UKN,0.081,0.004,gamb_colu,gambiae,False,True,True,False
+AG0446-CW,009-1015,AG1000G-GM-B,The Gambia,Sare Samba Sowe,2012,8,13.583,-15.9,UKN,0.089,0.006,gamb_colu,gambiae,False,True,True,False
+AG0448-CW,009-1022,AG1000G-GM-B,The Gambia,Sare Samba Sowe,2012,8,13.583,-15.9,F,0.105,0.005,gamb_colu,gambiae,False,True,True,False
+AG0450-CW,009-1026,AG1000G-GM-B,The Gambia,Sare Samba Sowe,2012,8,13.583,-15.9,UKN,0.067,0.005,gamb_colu,gambiae,False,True,True,False
+AG0451-CW,009-1030,AG1000G-GM-B,The Gambia,Sare Samba Sowe,2012,8,13.583,-15.9,UKN,0.899,0.005,gamb_colu,intermediate,False,True,False,False
+AG0454-CW,009-1065,AG1000G-GM-B,The Gambia,Sare Samba Sowe,2012,8,13.583,-15.9,UKN,0.112,0.005,gamb_colu,gambiae,False,True,True,False
+AG0455-CW,009-1070,AG1000G-GM-B,The Gambia,Sare Samba Sowe,2012,8,13.583,-15.9,UKN,0.078,0.005,gamb_colu,gambiae,False,True,True,False
+AG0456-CW,009-1071,AG1000G-GM-B,The Gambia,Sare Samba Sowe,2012,8,13.583,-15.9,UKN,0.103,0.006,gamb_colu,gambiae,False,True,True,False
+AG0460-CW,009-1129,AG1000G-GM-B,The Gambia,Sare Samba Sowe,2012,8,13.583,-15.9,UKN,0.078,0.005,gamb_colu,gambiae,False,True,True,False
+AG0001-C,I-73,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.943,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0003-C,I-78,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.966,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0004-C,I-79,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.943,0.006,gamb_colu,coluzzii,False,True,False,True
+AG0006-C,I-92,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.955,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0010-C,I-111,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.616,0.004,gamb_colu,intermediate,False,True,False,False
+AG0045-C,O-93,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.902,0.007,gamb_colu,coluzzii,False,True,False,True
+AG0047-C,O-108,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.912,0.006,gamb_colu,coluzzii,False,True,False,True
+AG0052-C,O-145,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.902,0.006,gamb_colu,coluzzii,False,True,False,True
+AG0055-C,O-161,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.933,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0056-C,O-171,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.936,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0058-C,O-187,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AG0061-C,O-206,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.958,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0002-C,I-74,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.942,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0005-C,I-80,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.92,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0014-C,I-119,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.927,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0015-C,I-124,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.955,0.006,gamb_colu,coluzzii,False,True,False,True
+AG0018-C,I-134,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.612,0.005,gamb_colu,intermediate,False,True,False,False
+AG0019-C,I-138,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.863,0.006,gamb_colu,intermediate,False,True,False,False
+AG0024-C,I-156,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.943,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0028-C,I-165,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.932,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0049-C,O-113,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.88,0.006,gamb_colu,intermediate,False,True,False,False
+AG0051-C,O-136,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.943,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0064-C,O-223,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.894,0.007,gamb_colu,intermediate,False,True,False,False
+AG0009-C,I-102,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.933,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0035-C,I-220,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.936,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0037-C,I-227,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.947,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0038-C,I-231,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.95,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0039-C,I-240,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.913,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0043-C,I-290,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.908,0.006,gamb_colu,coluzzii,False,True,False,True
+AG0068-C,O-271,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.957,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0071-C,O-283,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.894,0.005,gamb_colu,intermediate,False,True,False,False
+AG0072-C,O-287,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.903,0.006,gamb_colu,coluzzii,False,True,False,True
+AG0074-C,O-304,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.03,0.003,gamb_colu,gambiae,False,True,True,False
+AG0075-C,O-319,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.944,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0077-C,O-328,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.937,0.006,gamb_colu,coluzzii,False,True,False,True
+AG0007-C,I-97,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.939,0.006,gamb_colu,coluzzii,False,True,False,True
+AG0012-C,I-116,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.926,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0013-C,I-117,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.912,0.006,gamb_colu,coluzzii,False,True,False,True
+AG0016-C,I-130,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.892,0.006,gamb_colu,intermediate,False,True,False,False
+AG0029-C,I-168,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.921,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0031-C,I-193,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.908,0.006,gamb_colu,coluzzii,False,True,False,True
+AG0044-C,O-90,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.944,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0054-C,O-160,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.913,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0060-C,O-205,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.896,0.004,gamb_colu,intermediate,False,True,False,False
+AG0063-C,O-214,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.881,0.004,gamb_colu,intermediate,False,True,False,False
+AG0065-C,O-226,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.889,0.004,gamb_colu,intermediate,False,True,False,False
+AG0069-C,O-273,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.9,0.006,gamb_colu,intermediate,False,True,False,False
+AG0011-C,I-114,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.915,0.006,gamb_colu,coluzzii,False,True,False,True
+AG0020-C,I-144,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.921,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0022-C,I-150,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.952,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0023-C,I-151,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.934,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0025-C,I-158,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.898,0.005,gamb_colu,intermediate,False,True,False,False
+AG0027-C,I-164,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.949,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0032-C,I-207,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.927,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0048-C,O-112,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.923,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0059-C,O-204,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.932,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0062-C,O-211,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.939,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0066-C,O-235,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.948,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0076-C,O-325,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.912,0.006,gamb_colu,coluzzii,False,True,False,True
+AG0021-C,I-149,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.963,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0033-C,I-208,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.894,0.004,gamb_colu,intermediate,False,True,False,False
+AG0040-C,I-241,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.891,0.007,gamb_colu,intermediate,False,True,False,False
+AG0041-C,I-252,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.965,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0042-C,I-280,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.922,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0050-C,O-127,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.945,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0053-C,O-155,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.913,0.006,gamb_colu,coluzzii,False,True,False,True
+AG0067-C,O-270,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.912,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0375-C,O-455,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.956,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0290-C,I-429,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.919,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0330-C,I-35,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.927,0.007,gamb_colu,coluzzii,False,True,False,True
+AG0314-C,O-513,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.934,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0279-C,I-362,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.905,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0289-C,O-418,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.95,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0352-C,I-311,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.939,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0356-C,O-351,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.908,0.006,gamb_colu,coluzzii,False,True,False,True
+AG0307-C,I-3,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.809,0.007,gamb_colu,intermediate,False,True,False,False
+AG0359-C,I-10,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.93,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0310-C,I-9,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.945,0.006,gamb_colu,coluzzii,False,True,False,True
+AG0293-C,I-462,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.964,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0327-C,I-5,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.934,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0337-C,I-63,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.909,0.007,gamb_colu,coluzzii,False,True,False,True
+AG0366-C,O-456,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.879,0.006,gamb_colu,intermediate,False,True,False,False
+AG0270-C,O-99,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.936,0.006,gamb_colu,coluzzii,False,True,False,True
+AG0334-C,I-55,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.932,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0273-C,O-342,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.9,0.006,gamb_colu,coluzzii,False,True,False,True
+AG0306-C,I-1,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.927,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0329-C,I-17,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.922,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0344-C,I-224,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.89,0.005,gamb_colu,intermediate,False,True,False,False
+AG0296-C,I-473,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.955,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0285-C,I-397,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.948,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0304-C,I-506,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.924,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0349-C,I-300,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.926,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0320-C,I-37,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.896,0.007,gamb_colu,intermediate,False,True,False,False
+AG0323-C,I-41,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.953,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0373-C,O-379,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.93,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0298-C,I-477,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.904,0.006,gamb_colu,coluzzii,False,True,False,True
+AG0369-C,I-51,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.883,0.005,gamb_colu,intermediate,False,True,False,False
+AG0283-C,O-388,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.955,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0275-C,O-350,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.936,0.003,gamb_colu,coluzzii,False,True,False,True
+AG0272-C,O-339,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.92,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0299-C,I-487,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.943,0.006,gamb_colu,coluzzii,False,True,False,True
+AG0315-C,O-514,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.923,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0353-C,I-312,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.947,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0318-C,I-32,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.918,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0317-C,I-29,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.949,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0374-C,O-394,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.923,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0360-C,I-369,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.877,0.006,gamb_colu,intermediate,False,True,False,False
+AG0341-C,I-72,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.932,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0302-C,O-503,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.945,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0357-C,O-358,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.957,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0284-C,O-389,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.927,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0324-C,I-42,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.963,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0342-C,I-128,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.915,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0287-C,O-405,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.923,0.006,gamb_colu,coluzzii,False,True,False,True
+AG0351-C,I-303,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.951,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0377-C,O-483,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.944,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0281-C,I-370,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.937,0.006,gamb_colu,coluzzii,False,True,False,True
+AG0371-C,O-356,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.933,0.006,gamb_colu,coluzzii,False,True,False,True
+AG0277-C,I-355,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.936,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0339-C,I-69,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.936,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0336-C,I-62,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.928,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0348-C,I-299,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.941,0.006,gamb_colu,coluzzii,False,True,False,True
+AG0295-C,I-468,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.927,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0326-C,I-2,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.954,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0319-C,I-36,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.952,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0300-C,I-489,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.897,0.005,gamb_colu,intermediate,False,True,False,False
+AG0367-C,O-458,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.926,0.006,gamb_colu,coluzzii,False,True,False,True
+AG0274-C,O-349,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.951,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0343-C,I-131,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.909,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0358-C,O-368,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.93,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0335-C,I-61,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.953,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0346-C,I-296,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.875,0.006,gamb_colu,intermediate,False,True,False,False
+AG0294-C,I-466,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.915,0.006,gamb_colu,coluzzii,False,True,False,True
+AG0354-C,I-322,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.966,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0368-C,O-484,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.925,0.006,gamb_colu,coluzzii,False,True,False,True
+AG0311-C,I-12,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.943,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0355-C,I-330,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.913,0.006,gamb_colu,coluzzii,False,True,False,True
+AG0332-C,I-47,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.94,0.003,gamb_colu,coluzzii,False,True,False,True
+AG0361-C,O-375,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.943,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0305-C,I-507,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.867,0.006,gamb_colu,intermediate,False,True,False,False
+AG0363-C,O-391,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.937,0.003,gamb_colu,coluzzii,False,True,False,True
+AG0331-C,I-46,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.914,0.006,gamb_colu,coluzzii,False,True,False,True
+AG0309-C,I-6,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.924,0.006,gamb_colu,coluzzii,False,True,False,True
+AG0333-C,I-49,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.966,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0338-C,I-64,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.922,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0350-C,I-302,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.932,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0321-C,O-38,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.943,0.006,gamb_colu,coluzzii,False,True,False,True
+AG0278-C,O-361,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.929,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0308-C,I-4,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.928,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0376-C,I-460,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.879,0.005,gamb_colu,intermediate,False,True,False,False
+AG0370-C,I-66,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.913,0.006,gamb_colu,coluzzii,False,True,False,True
+AG0372-C,O-366,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.941,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0325-C,I-44,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.929,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0292-C,O-435,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.937,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0297-C,I-475,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.925,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0282-C,O-374,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.918,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0347-C,I-298,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.916,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0364-C,O-442,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.914,0.006,gamb_colu,coluzzii,False,True,False,True
+AG0328-C,I-8,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.943,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0286-C,I-402,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.943,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0365-C,I-449,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.917,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0276-C,O-354,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.955,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0271-C,O-334,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.922,0.006,gamb_colu,coluzzii,False,True,False,True
+AG0345-C,I-263,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.933,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0291-C,O-434,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.93,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0362-C,O-377,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.944,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0340-C,I-71,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.906,0.006,gamb_colu,coluzzii,False,True,False,True
+AG0288-C,O-411,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.929,0.006,gamb_colu,coluzzii,False,True,False,True
+AG0322-C,O-39,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.955,0.004,gamb_colu,coluzzii,False,True,False,True
+AG0312-C,I-14,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.913,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0316-C,I-18,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.932,0.006,gamb_colu,coluzzii,False,True,False,True
+AG0303-C,O-504,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.939,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0301-C,O-494,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.901,0.005,gamb_colu,coluzzii,False,True,False,True
+AG0313-C,I-15,AG1000G-GM-C,The Gambia,Wali Kunda,2012,10,13.567,-14.917,F,0.922,0.005,gamb_colu,coluzzii,False,True,False,True
+AV0043-C,KD306,AG1000G-GN-A,Guinea,Koundara,2012,10,8.48,-9.53,F,0.03,0.003,gamb_colu,gambiae,False,True,True,False
+AV0036-C,KD170,AG1000G-GN-A,Guinea,Koundara,2012,10,8.48,-9.53,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AV0025-C,KB281,AG1000G-GN-A,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AV0037-C,KD177,AG1000G-GN-A,Guinea,Koundara,2012,10,8.48,-9.53,F,0.033,0.003,gamb_colu,gambiae,False,True,True,False
+AV0026-C,KD005,AG1000G-GN-A,Guinea,Koundara,2012,10,8.48,-9.53,F,0.037,0.002,gamb_colu,gambiae,False,True,True,False
+AV0006-C,KB016,AG1000G-GN-A,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AV0008-C,KB051,AG1000G-GN-A,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+AV0015-C,KB089,AG1000G-GN-A,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+AV0010-C,KB057,AG1000G-GN-A,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.02,0.002,gamb_colu,gambiae,False,True,True,False
+AV0032-C,KD130,AG1000G-GN-A,Guinea,Koundara,2012,10,8.48,-9.53,F,0.015,0.002,gamb_colu,gambiae,False,True,True,False
+AV0007-C,KB041,AG1000G-GN-A,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.406,0.002,gamb_colu,intermediate,False,True,False,False
+AV0035-C,KD159,AG1000G-GN-A,Guinea,Koundara,2012,10,8.48,-9.53,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AV0012-C,KB066,AG1000G-GN-A,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.02,0.002,gamb_colu,gambiae,False,True,True,False
+AV0024-C,KB162,AG1000G-GN-A,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.049,0.002,gamb_colu,gambiae,False,True,True,False
+AV0031-C,KD105,AG1000G-GN-A,Guinea,Koundara,2012,10,8.48,-9.53,F,0.019,0.002,gamb_colu,gambiae,False,True,True,False
+AV0002-C,KB002,AG1000G-GN-A,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AV0014-C,KB088,AG1000G-GN-A,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.015,0.002,gamb_colu,gambiae,False,True,True,False
+AV0013-C,KB081,AG1000G-GN-A,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.041,0.002,gamb_colu,gambiae,False,True,True,False
+AV0005-C,KB010,AG1000G-GN-A,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AV0011-C,KB058,AG1000G-GN-A,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.022,0.003,gamb_colu,gambiae,False,True,True,False
+AV0027-C,KD029,AG1000G-GN-A,Guinea,Koundara,2012,10,8.48,-9.53,F,0.019,0.002,gamb_colu,gambiae,False,True,True,False
+AV0018-C,KB111,AG1000G-GN-A,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.015,0.002,gamb_colu,gambiae,False,True,True,False
+AV0047-C,KD363,AG1000G-GN-A,Guinea,Koundara,2012,10,8.48,-9.53,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AV0038-C,KD246,AG1000G-GN-A,Guinea,Koundara,2012,10,8.48,-9.53,F,0.952,0.003,gamb_colu,coluzzii,False,True,False,True
+AV0040-C,KD255,AG1000G-GN-A,Guinea,Koundara,2012,10,8.48,-9.53,F,0.962,0.003,gamb_colu,coluzzii,False,True,False,True
+AV0039-C,KD248,AG1000G-GN-A,Guinea,Koundara,2012,10,8.48,-9.53,F,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+AV0009-C,KB054,AG1000G-GN-A,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AV0001-C,KB001,AG1000G-GN-A,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.012,0.002,gamb_colu,gambiae,False,True,True,False
+AV0041-C,KD264,AG1000G-GN-A,Guinea,Koundara,2012,10,8.48,-9.53,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AV0033-C,KD148,AG1000G-GN-A,Guinea,Koundara,2012,10,8.48,-9.53,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AV0045-C,KD339,AG1000G-GN-A,Guinea,Koundara,2012,10,8.48,-9.53,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AV0017-C,KB110,AG1000G-GN-A,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.033,0.002,gamb_colu,gambiae,False,True,True,False
+AV0022-C,KB128,AG1000G-GN-A,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AV0020-C,KB118,AG1000G-GN-A,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AV0021-C,KB124,AG1000G-GN-A,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AV0028-C,KD034,AG1000G-GN-A,Guinea,Koundara,2012,10,8.48,-9.53,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AV0023-C,KB152,AG1000G-GN-A,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.03,0.002,gamb_colu,gambiae,False,True,True,False
+AV0042-Cx,KD277,AG1000G-GN-A,Guinea,Koundara,2012,10,8.48,-9.53,F,0.966,0.003,gamb_colu,coluzzii,False,True,False,True
+AV0044-Cx,KD309,AG1000G-GN-A,Guinea,Koundara,2012,10,8.48,-9.53,F,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+AV0004-Cx,KB008,AG1000G-GN-A,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.039,0.002,gamb_colu,gambiae,False,True,True,False
+AV0030-Cx,KD104,AG1000G-GN-A,Guinea,Koundara,2012,10,8.48,-9.53,F,0.016,0.002,gamb_colu,gambiae,False,True,True,False
+AV0046-Cx,KD353,AG1000G-GN-A,Guinea,Koundara,2012,10,8.48,-9.53,F,0.95,0.003,gamb_colu,coluzzii,False,True,False,True
+AV0029-Cx,KD044,AG1000G-GN-A,Guinea,Koundara,2012,10,8.48,-9.53,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AV0034-Cx,KD156,AG1000G-GN-A,Guinea,Koundara,2012,10,8.48,-9.53,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AV0003-Cx,KB003,AG1000G-GN-A,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.04,0.002,gamb_colu,gambiae,False,True,True,False
+AV0069-CW,KV0446,AG1000G-GN-B,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AV0126-CW,KV0270,AG1000G-GN-B,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.153,0.002,gamb_colu,intermediate,False,True,False,False
+AV0209-CW,KV0768,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,F,0.945,0.003,gamb_colu,coluzzii,False,True,False,True
+AV0235-CW,KV0890,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,F,0.01,0.002,gamb_colu,gambiae,False,True,True,False
+AV0132-C,KV0186,AG1000G-GN-B,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AV0061-C,KV0189,AG1000G-GN-B,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.063,0.002,gamb_colu,gambiae,False,True,True,False
+AV0109-C,KV0195,AG1000G-GN-B,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AV0074-C,KV0201,AG1000G-GN-B,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.017,0.002,gamb_colu,gambiae,False,True,True,False
+AV0086-C,KV0202,AG1000G-GN-B,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.036,0.002,gamb_colu,gambiae,False,True,True,False
+AV0098-C,KV0205,AG1000G-GN-B,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AV0134-C,KV0209,AG1000G-GN-B,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.083,0.002,gamb_colu,gambiae,False,True,True,False
+AV0113-C,KV0244,AG1000G-GN-B,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.044,0.002,gamb_colu,gambiae,False,True,True,False
+AV0137-C,KV0248,AG1000G-GN-B,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.019,0.002,gamb_colu,gambiae,False,True,True,False
+AV0078-C,KV0256,AG1000G-GN-B,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+AV0055-C,KV0275,AG1000G-GN-B,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.025,0.003,gamb_colu,gambiae,False,True,True,False
+AV0067-C,KV0280,AG1000G-GN-B,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.014,0.002,gamb_colu,gambiae,False,True,True,False
+AV0091-C,KV0301,AG1000G-GN-B,Guinea,Koraboh,2012,10,9.28,-10.03,M,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+AV0115-C,KV0311,AG1000G-GN-B,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AV0068-C,KV0325,AG1000G-GN-B,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.031,0.002,gamb_colu,gambiae,False,True,True,False
+AV0080-C,KV0333,AG1000G-GN-B,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.019,0.002,gamb_colu,gambiae,False,True,True,False
+AV0092-C,KV0335,AG1000G-GN-B,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AV0104-C,KV0340,AG1000G-GN-B,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.079,0.002,gamb_colu,gambiae,False,True,True,False
+AV0116-C,KV0343,AG1000G-GN-B,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AV0128-C,KV0344,AG1000G-GN-B,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+AV0140-C,KV0347,AG1000G-GN-B,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AV0129-C,KV0455,AG1000G-GN-B,Guinea,Koraboh,2012,10,9.28,-10.03,M,0.058,0.002,gamb_colu,gambiae,False,True,True,False
+AV0141-C,KV0457,AG1000G-GN-B,Guinea,Koraboh,2012,10,9.28,-10.03,M,0.03,0.003,gamb_colu,gambiae,False,True,True,False
+AV0058-C,KV0459,AG1000G-GN-B,Guinea,Koraboh,2012,10,9.28,-10.03,M,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AV0070-C,KV0461,AG1000G-GN-B,Guinea,Koraboh,2012,10,9.28,-10.03,M,0.054,0.002,gamb_colu,gambiae,False,True,True,False
+AV0082-C,KV0462,AG1000G-GN-B,Guinea,Koraboh,2012,10,9.28,-10.03,M,0.023,0.003,gamb_colu,gambiae,False,True,True,False
+AV0094-C,KV0464,AG1000G-GN-B,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.019,0.002,gamb_colu,gambiae,False,True,True,False
+AV0106-C,KV0465,AG1000G-GN-B,Guinea,Koraboh,2012,10,9.28,-10.03,M,0.044,0.002,gamb_colu,gambiae,False,True,True,False
+AV0130-C,KV0469,AG1000G-GN-B,Guinea,Koraboh,2012,10,9.28,-10.03,M,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AV0059-C,KV0475,AG1000G-GN-B,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.028,0.002,gamb_colu,gambiae,False,True,True,False
+AV0083-C,KV0477,AG1000G-GN-B,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.028,0.002,gamb_colu,gambiae,False,True,True,False
+AV0095-C,KV0479,AG1000G-GN-B,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AV0107-C,KV0480,AG1000G-GN-B,Guinea,Koraboh,2012,10,9.28,-10.03,M,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AV0119-C,KV0482,AG1000G-GN-B,Guinea,Koraboh,2012,10,9.28,-10.03,F,0.015,0.002,gamb_colu,gambiae,False,True,True,False
+AV0131-C,KV0484,AG1000G-GN-B,Guinea,Koraboh,2012,10,9.28,-10.03,M,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AV0142-C,KV0630,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AV0154-C,KV0631,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,F,0.017,0.002,gamb_colu,gambiae,False,True,True,False
+AV0226-C,KV0638,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AV0143-C,KV0639,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,F,0.017,0.002,gamb_colu,gambiae,False,True,True,False
+AV0179-C,KV0642,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AV0191-C,KV0644,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,F,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+AV0180-C,KV0653,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AV0192-C,KV0654,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AV0170-C,KV0675,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,F,0.059,0.002,gamb_colu,gambiae,False,True,True,False
+AV0194-C,KV0677,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,F,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+AV0206-C,KV0691,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,F,0.038,0.002,gamb_colu,gambiae,False,True,True,False
+AV0218-C,KV0694,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AV0171-C,KV0717,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,F,0.027,0.003,gamb_colu,gambiae,False,True,True,False
+AV0195-C,KV0723,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AV0207-C,KV0725,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,F,0.967,0.003,gamb_colu,coluzzii,False,True,False,True
+AV0330-C,KV1269,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+AV0342-C,KV1294,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AV0354-C,KV1285,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+AV0366-C,KV1305,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.984,0.002,gamb_colu,coluzzii,False,True,False,True
+AV0377-C,KV1298,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AV0387-C,KV1303,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AV0407-C,KV1326,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.016,0.002,gamb_colu,gambiae,False,True,True,False
+AV0331-C,KV1333,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.503,0.002,gamb_colu,intermediate,False,True,False,False
+AV0367-C,KV1337,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.02,0.003,gamb_colu,gambiae,False,True,True,False
+AV0378-C,KV1339,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AV0408-C,KV1352,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.016,0.002,gamb_colu,gambiae,False,True,True,False
+AV0332-C,KV1355,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+AV0344-C,KV1357,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.061,0.002,gamb_colu,gambiae,False,True,True,False
+AV0356-C,KV1370,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.022,0.003,gamb_colu,gambiae,False,True,True,False
+AV0368-C,KV1371,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AV0389-C,KV1378,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AV0409-C,KV1395,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.019,0.002,gamb_colu,gambiae,False,True,True,False
+AV0333-C,KV1397,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.017,0.002,gamb_colu,gambiae,False,True,True,False
+AV0380-C,KV1404,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.067,0.002,gamb_colu,gambiae,False,True,True,False
+AV0390-C,KV1405,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.016,0.002,gamb_colu,gambiae,False,True,True,False
+AV0400-C,KV1407,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+AV0410-C,KV1410,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.02,0.002,gamb_colu,gambiae,False,True,True,False
+AV0334-C,KV1414,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AV0346-C,KV1416,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AV0358-C,KV1419,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AV0381-C,KV1423,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AV0391-C,KV1427,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AV0401-C,KV1430,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+AV0335-C,KV1440,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AV0347-C,KV1444,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.019,0.002,gamb_colu,gambiae,False,True,True,False
+AV0359-C,KV1451,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.019,0.002,gamb_colu,gambiae,False,True,True,False
+AV0371-C,KV1453,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.034,0.002,gamb_colu,gambiae,False,True,True,False
+AV0382-C,KV1454,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AV0392-C,KV1458,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AV0402-C,KV1462,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.019,0.002,gamb_colu,gambiae,False,True,True,False
+AV0412-C,KV1466,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+AV0336-C,KV1468,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AV0360-C,KV1476,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AV0372-C,KV1480,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.033,0.002,gamb_colu,gambiae,False,True,True,False
+AV0383-C,KV1484,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AV0393-C,KV1485,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AV0403-C,KV1486,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.017,0.002,gamb_colu,gambiae,False,True,True,False
+AV0337-C,KV1580,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,M,0.019,0.003,gamb_colu,gambiae,False,True,True,False
+AV0349-C,KV1582,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,M,0.02,0.002,gamb_colu,gambiae,False,True,True,False
+AV0361-C,KV1583,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.03,0.002,gamb_colu,gambiae,False,True,True,False
+AV0373-C,KV1587,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,M,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AV0384-C,KV1592,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.014,0.002,gamb_colu,gambiae,False,True,True,False
+AV0394-C,KV1595,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,M,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AV0404-C,KV1596,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,M,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AV0414-C,KV1598,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,M,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AV0338-C,KV1599,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.02,0.002,gamb_colu,gambiae,False,True,True,False
+AV0350-C,KV1602,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AV0362-C,KV1607,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,M,0.033,0.003,gamb_colu,gambiae,False,True,True,False
+AV0405-C,KV1614,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.016,0.002,gamb_colu,gambiae,False,True,True,False
+AV0415-C,KV1616,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,M,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AV0351-C,KV1619,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+AV0363-C,KV1620,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AV0375-C,KV1621,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,M,0.012,0.002,gamb_colu,gambiae,False,True,True,False
+AV0386-C,KV1623,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.014,0.002,gamb_colu,gambiae,False,True,True,False
+AV0396-C,KV1624,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,M,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AV0406-C,KV1625,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AV0340-C,KV1627,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,M,0.976,0.002,gamb_colu,coluzzii,False,True,False,True
+AV0352-C,KV0487,AG1000G-GN-B,Guinea,Koraboh,2012,10,9.28,-10.03,M,0.019,0.002,gamb_colu,gambiae,False,True,True,False
+AV0364-C,KV0914,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,M,0.066,0.002,gamb_colu,gambiae,False,True,True,False
+AV0376-C,KV1314,AG1000G-GN-B,Mali,Toumani Oulena,2012,10,10.83,-7.81,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AV0341-C,KV0472,AG1000G-GN-B,Guinea,Koraboh,2012,10,9.28,-10.03,M,0.017,0.002,gamb_colu,gambiae,False,True,True,False
+AV0353-C,KV0903,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,M,0.075,0.002,gamb_colu,gambiae,False,True,True,False
+AV0219-C,KV0728,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,F,0.019,0.002,gamb_colu,gambiae,False,True,True,False
+AV0231-C,KV0730,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,F,0.033,0.002,gamb_colu,gambiae,False,True,True,False
+AV0160-C,KV0739,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AV0196-C,KV0746,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,F,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+AV0208-C,KV0748,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,F,0.02,0.002,gamb_colu,gambiae,False,True,True,False
+AV0220-C,KV0753,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,F,0.963,0.003,gamb_colu,coluzzii,False,True,False,True
+AV0232-C,KV0754,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,F,0.969,0.003,gamb_colu,coluzzii,False,True,False,True
+AV0149-C,KV0758,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,F,0.94,0.002,gamb_colu,coluzzii,False,True,False,True
+AV0161-C,KV0762,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,F,0.956,0.003,gamb_colu,coluzzii,False,True,False,True
+AV0173-C,KV0764,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,F,0.974,0.002,gamb_colu,coluzzii,False,True,False,True
+AV0185-C,KV0765,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,F,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+AV0150-C,KV0869,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,M,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+AV0162-C,KV0872,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,F,0.02,0.002,gamb_colu,gambiae,False,True,True,False
+AV0174-C,KV0873,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,M,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+AV0186-C,KV0874,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,F,0.03,0.002,gamb_colu,gambiae,False,True,True,False
+AV0198-C,KV0876,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AV0210-C,KV0877,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AV0222-C,KV0879,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,M,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AV0234-C,KV0881,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,M,0.015,0.002,gamb_colu,gambiae,False,True,True,False
+AV0199-C,KV0886,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AV0211-C,KV0888,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,M,0.031,0.002,gamb_colu,gambiae,False,True,True,False
+AV0223-C,KV0889,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,M,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AV0152-C,KV0892,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,M,0.024,0.003,gamb_colu,gambiae,False,True,True,False
+AV0164-C,KV0895,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AV0176-C,KV0896,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,M,0.021,0.003,gamb_colu,gambiae,False,True,True,False
+AV0188-C,KV0897,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AV0200-C,KV0899,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AV0165-C,KV0905,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,M,0.036,0.003,gamb_colu,gambiae,False,True,True,False
+AV0177-C,KV0906,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AV0189-C,KV0907,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AV0201-C,KV0909,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AV0213-C,KV0910,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,M,0.033,0.002,gamb_colu,gambiae,False,True,True,False
+AV0225-C,KV0911,AG1000G-GN-B,Guinea,Koundara,2012,10,8.48,-9.53,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AV0236-C,KV0924,AG1000G-GN-B,Mali,Takan,2012,10,11.47,-8.33,F,0.975,0.002,gamb_colu,coluzzii,False,True,False,True
+AV0248-C,KV0926,AG1000G-GN-B,Mali,Takan,2012,10,11.47,-8.33,F,0.969,0.002,gamb_colu,coluzzii,False,True,False,True
+AV0308-C,KV0930,AG1000G-GN-B,Mali,Takan,2012,10,11.47,-8.33,F,0.972,0.002,gamb_colu,coluzzii,False,True,False,True
+AV0320-C,KV0940,AG1000G-GN-B,Mali,Takan,2012,10,11.47,-8.33,F,0.983,0.002,gamb_colu,coluzzii,False,True,False,True
+AV0237-C,KV0941,AG1000G-GN-B,Mali,Takan,2012,10,11.47,-8.33,F,0.986,0.002,gamb_colu,coluzzii,False,True,False,True
+AV0249-C,KV0957,AG1000G-GN-B,Mali,Takan,2012,10,11.47,-8.33,F,0.983,0.002,gamb_colu,coluzzii,False,True,False,True
+AV0285-C,KV0972,AG1000G-GN-B,Mali,Takan,2012,10,11.47,-8.33,F,0.982,0.002,gamb_colu,coluzzii,False,True,False,True
+AV0297-C,KV0973,AG1000G-GN-B,Mali,Takan,2012,10,11.47,-8.33,F,0.978,0.002,gamb_colu,coluzzii,False,True,False,True
+AV0262-C,KV1005,AG1000G-GN-B,Mali,Takan,2012,10,11.47,-8.33,F,0.967,0.002,gamb_colu,coluzzii,False,True,False,True
+AV0263-C,KV1046,AG1000G-GN-B,Mali,Takan,2012,10,11.47,-8.33,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AV0275-C,KV1047,AG1000G-GN-B,Mali,Takan,2012,10,11.47,-8.33,F,0.967,0.002,gamb_colu,coluzzii,False,True,False,True
+AV0287-C,KV1049,AG1000G-GN-B,Mali,Takan,2012,10,11.47,-8.33,F,0.021,0.003,gamb_colu,gambiae,False,True,True,False
+AV0323-C,KV1074,AG1000G-GN-B,Mali,Takan,2012,10,11.47,-8.33,F,0.98,0.002,gamb_colu,coluzzii,False,True,False,True
+AV0241-C,KV1105,AG1000G-GN-B,Mali,Takan,2012,10,11.47,-8.33,F,0.987,0.002,gamb_colu,coluzzii,False,True,False,True
+AV0253-C,KV1109,AG1000G-GN-B,Mali,Takan,2012,10,11.47,-8.33,F,0.969,0.002,gamb_colu,coluzzii,False,True,False,True
+AV0265-C,KV1112,AG1000G-GN-B,Mali,Takan,2012,10,11.47,-8.33,F,0.983,0.002,gamb_colu,coluzzii,False,True,False,True
+AV0277-C,KV1116,AG1000G-GN-B,Mali,Takan,2012,10,11.47,-8.33,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AV0325-C,KV1219,AG1000G-GN-B,Mali,Takan,2012,10,11.47,-8.33,M,0.03,0.002,gamb_colu,gambiae,False,True,True,False
+AV0254-C,KV1222,AG1000G-GN-B,Mali,Takan,2012,10,11.47,-8.33,F,0.971,0.002,gamb_colu,coluzzii,False,True,False,True
+AV0278-C,KV1225,AG1000G-GN-B,Mali,Takan,2012,10,11.47,-8.33,F,0.973,0.002,gamb_colu,coluzzii,False,True,False,True
+AV0314-C,KV1234,AG1000G-GN-B,Mali,Takan,2012,10,11.47,-8.33,M,0.056,0.002,gamb_colu,gambiae,False,True,True,False
+AV0243-C,KV1237,AG1000G-GN-B,Mali,Takan,2012,10,11.47,-8.33,F,0.966,0.002,gamb_colu,coluzzii,False,True,False,True
+AV0255-C,KV1238,AG1000G-GN-B,Mali,Takan,2012,10,11.47,-8.33,M,0.907,0.003,gamb_colu,coluzzii,False,True,False,True
+AV0303-C,KV1251,AG1000G-GN-B,Mali,Takan,2012,10,11.47,-8.33,F,0.978,0.002,gamb_colu,coluzzii,False,True,False,True
+AV0268-C,KV1257,AG1000G-GN-B,Mali,Takan,2012,10,11.47,-8.33,M,0.962,0.002,gamb_colu,coluzzii,False,True,False,True
+AV0280-C,KV1258,AG1000G-GN-B,Mali,Takan,2012,10,11.47,-8.33,M,0.983,0.002,gamb_colu,coluzzii,False,True,False,True
+AV0292-C,KV1259,AG1000G-GN-B,Mali,Takan,2012,10,11.47,-8.33,M,0.97,0.002,gamb_colu,coluzzii,False,True,False,True
+AV0304-C,KV1260,AG1000G-GN-B,Mali,Takan,2012,10,11.47,-8.33,F,0.97,0.002,gamb_colu,coluzzii,False,True,False,True
+AV0245-C,KV1121,AG1000G-GN-B,Mali,Takan,2012,10,11.47,-8.33,F,0.99,0.002,gamb_colu,coluzzii,False,True,False,True
+AV0293-C,KV1165,AG1000G-GN-B,Mali,Takan,2012,10,11.47,-8.33,F,0.982,0.002,gamb_colu,coluzzii,False,True,False,True
+AV0305-C,KV1172,AG1000G-GN-B,Mali,Takan,2012,10,11.47,-8.33,F,0.987,0.002,gamb_colu,coluzzii,False,True,False,True
+AQ0009-C,C6TL.1,AG1000G-GQ,Bioko,Bioko,2002,9,3.7,8.7,F,0.063,0.002,gamb_colu,gambiae,False,True,True,False
+AQ0001-C,1C58.5,AG1000G-GQ,Bioko,Bioko,2002,9,3.7,8.7,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AQ0002-C,1C58.6,AG1000G-GQ,Bioko,Bioko,2002,9,3.7,8.7,F,0.063,0.002,gamb_colu,gambiae,False,True,True,False
+AQ0005-C,C58.2,AG1000G-GQ,Bioko,Bioko,2002,9,3.7,8.7,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AQ0004-C,C58.1,AG1000G-GQ,Bioko,Bioko,2002,9,3.7,8.7,F,0.064,0.002,gamb_colu,gambiae,False,True,True,False
+AQ0015-C,TL9.2,AG1000G-GQ,Bioko,Bioko,2002,9,3.7,8.7,F,0.037,0.002,gamb_colu,gambiae,False,True,True,False
+AQ0011-C,TL58.6,AG1000G-GQ,Bioko,Bioko,2002,9,3.7,8.7,F,0.046,0.002,gamb_colu,gambiae,False,True,True,False
+AQ0012-C,TL58.1,AG1000G-GQ,Bioko,Bioko,2002,9,3.7,8.7,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AQ0014-C,TL9.1,AG1000G-GQ,Bioko,Bioko,2002,9,3.7,8.7,F,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+AQ0013-C,TL58.4,AG1000G-GQ,Bioko,Bioko,2002,9,3.7,8.7,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AJ0023-C,BIS001,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.08,0.006,gamb_colu,gambiae,False,True,True,False
+AJ0024-C,BIS002,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.431,0.007,gamb_colu,intermediate,False,True,False,False
+AJ0032-C,BIS010,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.369,0.006,gamb_colu,intermediate,False,True,False,False
+AJ0035-C,BIS013,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.118,0.007,gamb_colu,gambiae,False,True,True,False
+AJ0036-C,BIS014,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.125,0.005,gamb_colu,intermediate,False,True,False,False
+AJ0037-C,BIS015,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.673,0.007,gamb_colu,intermediate,False,True,False,False
+AJ0039-C,BIS017,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.095,0.005,gamb_colu,gambiae,False,True,True,False
+AJ0043-C,BIS021,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.188,0.006,gamb_colu,intermediate,False,True,False,False
+AJ0044-C,BIS022,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.132,0.006,gamb_colu,intermediate,False,True,False,False
+AJ0045-C,BIS023,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.127,0.005,gamb_colu,intermediate,False,True,False,False
+AJ0047-C,BIS025,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.281,0.008,gamb_colu,intermediate,False,True,False,False
+AJ0051-C,BIS029,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.179,0.005,gamb_colu,intermediate,False,True,False,False
+AJ0052-C,BIS030,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.356,0.006,gamb_colu,intermediate,False,True,False,False
+AJ0056-C,BIS034,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.093,0.005,gamb_colu,gambiae,False,True,True,False
+AJ0059-C,BIS037,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.105,0.005,gamb_colu,gambiae,False,True,True,False
+AJ0061-C,BIS039,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.105,0.005,gamb_colu,gambiae,False,True,True,False
+AJ0063-C,BIS041,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.133,0.006,gamb_colu,intermediate,False,True,False,False
+AJ0064-C,BIS042,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.414,0.008,gamb_colu,intermediate,False,True,False,False
+AJ0066-C,BIS044,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.322,0.005,gamb_colu,intermediate,False,True,False,False
+AJ0071-C,BIS049,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.116,0.006,gamb_colu,gambiae,False,True,True,False
+AJ0072-C,BIS050,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.106,0.006,gamb_colu,gambiae,False,True,True,False
+AJ0074-C,BIS052,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.429,0.006,gamb_colu,intermediate,False,True,False,False
+AJ0075-C,BIS053,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.397,0.005,gamb_colu,intermediate,False,True,False,False
+AJ0076-C,BIS054,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.177,0.005,gamb_colu,intermediate,False,True,False,False
+AJ0077-C,BIS055,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.553,0.007,gamb_colu,intermediate,False,True,False,False
+AJ0078-C,BIS056,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.437,0.007,gamb_colu,intermediate,False,True,False,False
+AJ0079-C,BIS057,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.816,0.006,gamb_colu,intermediate,False,True,False,False
+AJ0081-C,BIS059,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.146,0.005,gamb_colu,intermediate,False,True,False,False
+AJ0084-C,BIS062,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.185,0.006,gamb_colu,intermediate,False,True,False,False
+AJ0085-C,BIS063,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.114,0.005,gamb_colu,gambiae,False,True,True,False
+AJ0086-C,BIS064,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.217,0.007,gamb_colu,intermediate,False,True,False,False
+AJ0088-C,BIS066,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.152,0.006,gamb_colu,intermediate,False,True,False,False
+AJ0090-C,BIS068,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.623,0.006,gamb_colu,intermediate,False,True,False,False
+AJ0092-C,BIS070,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.127,0.007,gamb_colu,intermediate,False,True,False,False
+AJ0093-C,BIS071,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.421,0.006,gamb_colu,intermediate,False,True,False,False
+AJ0095-C,BIS073,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.229,0.006,gamb_colu,intermediate,False,True,False,False
+AJ0096-C,BIS074,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.131,0.006,gamb_colu,intermediate,False,True,False,False
+AJ0097-C,BIS075,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.113,0.006,gamb_colu,gambiae,False,True,True,False
+AJ0098-C,BIS076,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.182,0.005,gamb_colu,intermediate,False,True,False,False
+AJ0100-C,BIS078,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.14,0.006,gamb_colu,intermediate,False,True,False,False
+AJ0102-C,BIS080,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.328,0.006,gamb_colu,intermediate,False,True,False,False
+AJ0103-C,BIS081,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.18,0.005,gamb_colu,intermediate,False,True,False,False
+AJ0105-C,BIS083,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.186,0.005,gamb_colu,intermediate,False,True,False,False
+AJ0107-C,BIS085,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.108,0.006,gamb_colu,gambiae,False,True,True,False
+AJ0109-C,BIS087,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.306,0.006,gamb_colu,intermediate,False,True,False,False
+AJ0113-C,BIS091,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.099,0.004,gamb_colu,gambiae,False,True,True,False
+AJ0115-C,BIS093,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.337,0.006,gamb_colu,intermediate,False,True,False,False
+AJ0116-C,BIS094,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.29,0.007,gamb_colu,intermediate,False,True,False,False
+AJ0099-C,BIS077,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.133,0.007,gamb_colu,intermediate,False,True,False,False
+AJ0117-C,BIS095,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.103,0.005,gamb_colu,gambiae,False,True,True,False
+AJ0070-Cx,BIS048,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.19,0.006,gamb_colu,intermediate,False,True,False,False
+AJ0101-Cx,BIS079,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.387,0.007,gamb_colu,intermediate,False,True,False,False
+AJ0120-C,10GBL_0348,AG1000G-GW,Guinea-Bissau,Leibala,2010,-1,12.272,-14.222,F,0.032,0.003,gamb_colu,gambiae,False,True,True,False
+AJ0121-C,10GBL_0350,AG1000G-GW,Guinea-Bissau,Leibala,2010,-1,12.272,-14.222,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AJ0122-C,10GBL_0375,AG1000G-GW,Guinea-Bissau,Leibala,2010,-1,12.272,-14.222,F,0.045,0.002,gamb_colu,gambiae,False,True,True,False
+AJ0123-C,10GBL_0380,AG1000G-GW,Guinea-Bissau,Leibala,2010,-1,12.272,-14.222,F,0.033,0.002,gamb_colu,gambiae,False,True,True,False
+AJ0124-C,10GBL_0382,AG1000G-GW,Guinea-Bissau,Leibala,2010,-1,12.272,-14.222,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AJ0125-C,10GBL_0391,AG1000G-GW,Guinea-Bissau,Leibala,2010,-1,12.272,-14.222,F,0.036,0.002,gamb_colu,gambiae,False,True,True,False
+AJ0126-C,10GBL_0405,AG1000G-GW,Guinea-Bissau,Leibala,2010,-1,12.272,-14.222,F,0.049,0.003,gamb_colu,gambiae,False,True,True,False
+AJ0127-C,10GBL_0409,AG1000G-GW,Guinea-Bissau,Leibala,2010,-1,12.272,-14.222,F,0.037,0.002,gamb_colu,gambiae,False,True,True,False
+AJ0128-C,10GBS_0607,AG1000G-GW,Guinea-Bissau,Safim,2010,-1,11.957,-15.649,F,0.131,0.006,gamb_colu,intermediate,False,True,False,False
+AJ0129-C,10GBS_0660,AG1000G-GW,Guinea-Bissau,Safim,2010,-1,11.957,-15.649,F,0.318,0.006,gamb_colu,intermediate,False,True,False,False
+AJ0130-C,10GBS_0662,AG1000G-GW,Guinea-Bissau,Safim,2010,-1,11.957,-15.649,F,0.13,0.006,gamb_colu,intermediate,False,True,False,False
+AJ0131-C,10GBS_0683,AG1000G-GW,Guinea-Bissau,Safim,2010,-1,11.957,-15.649,F,0.108,0.005,gamb_colu,gambiae,False,True,True,False
+AJ0132-C,10GBS_0695,AG1000G-GW,Guinea-Bissau,Safim,2010,-1,11.957,-15.649,F,0.193,0.006,gamb_colu,intermediate,False,True,False,False
+AJ0133-C,10GBS_0895,AG1000G-GW,Guinea-Bissau,Safim,2010,-1,11.957,-15.649,F,0.103,0.005,gamb_colu,gambiae,False,True,True,False
+AJ0134-C,10GBS_0902,AG1000G-GW,Guinea-Bissau,Safim,2010,-1,11.957,-15.649,F,0.122,0.006,gamb_colu,intermediate,False,True,False,False
+AJ0135-C,10GBS_0907,AG1000G-GW,Guinea-Bissau,Safim,2010,-1,11.957,-15.649,F,0.219,0.005,gamb_colu,intermediate,False,True,False,False
+AJ0136-C,10GBS_0912,AG1000G-GW,Guinea-Bissau,Safim,2010,-1,11.957,-15.649,F,0.152,0.007,gamb_colu,intermediate,False,True,False,False
+AJ0137-C,10GBS_0913,AG1000G-GW,Guinea-Bissau,Safim,2010,-1,11.957,-15.649,F,0.147,0.007,gamb_colu,intermediate,False,True,False,False
+AJ0138-C,10GBS_0915,AG1000G-GW,Guinea-Bissau,Safim,2010,-1,11.957,-15.649,F,0.109,0.007,gamb_colu,gambiae,False,True,True,False
+AJ0139-C,10GBS_0916,AG1000G-GW,Guinea-Bissau,Safim,2010,-1,11.957,-15.649,F,0.138,0.006,gamb_colu,intermediate,False,True,False,False
+AJ0140-C,10GBS_0920,AG1000G-GW,Guinea-Bissau,Safim,2010,-1,11.957,-15.649,F,0.102,0.006,gamb_colu,gambiae,False,True,True,False
+AJ0141-C,10GBS_0925,AG1000G-GW,Guinea-Bissau,Safim,2010,-1,11.957,-15.649,F,0.24,0.005,gamb_colu,intermediate,False,True,False,False
+AJ0142-C,10GBS_0928,AG1000G-GW,Guinea-Bissau,Safim,2010,-1,11.957,-15.649,F,0.141,0.006,gamb_colu,intermediate,False,True,False,False
+AJ0143-C,10GBS_0932,AG1000G-GW,Guinea-Bissau,Safim,2010,-1,11.957,-15.649,F,0.207,0.005,gamb_colu,intermediate,False,True,False,False
+AJ0144-C,10GBS_0946,AG1000G-GW,Guinea-Bissau,Safim,2010,-1,11.957,-15.649,F,0.209,0.006,gamb_colu,intermediate,False,True,False,False
+AJ0145-C,10GBS_1151,AG1000G-GW,Guinea-Bissau,Safim,2010,-1,11.957,-15.649,F,0.11,0.005,gamb_colu,gambiae,False,True,True,False
+AJ0146-C,10GBS_1156,AG1000G-GW,Guinea-Bissau,Safim,2010,-1,11.957,-15.649,F,0.165,0.007,gamb_colu,intermediate,False,True,False,False
+AJ0147-C,10GBS_1157,AG1000G-GW,Guinea-Bissau,Safim,2010,-1,11.957,-15.649,F,0.343,0.006,gamb_colu,intermediate,False,True,False,False
+AJ0148-C,10GBS_1166,AG1000G-GW,Guinea-Bissau,Safim,2010,-1,11.957,-15.649,F,0.234,0.007,gamb_colu,intermediate,False,True,False,False
+AJ0149-C,10GBS_1178,AG1000G-GW,Guinea-Bissau,Safim,2010,-1,11.957,-15.649,F,0.178,0.005,gamb_colu,intermediate,False,True,False,False
+AJ0150-C,10GBS_1181,AG1000G-GW,Guinea-Bissau,Safim,2010,-1,11.957,-15.649,F,0.171,0.007,gamb_colu,intermediate,False,True,False,False
+AJ0151-C,10GBS_1189,AG1000G-GW,Guinea-Bissau,Safim,2010,-1,11.957,-15.649,F,0.13,0.006,gamb_colu,intermediate,False,True,False,False
+AJ0152-C,10GBS_1199,AG1000G-GW,Guinea-Bissau,Safim,2010,-1,11.957,-15.649,F,0.163,0.006,gamb_colu,intermediate,False,True,False,False
+AJ0153-C,10GBS_1201,AG1000G-GW,Guinea-Bissau,Safim,2010,-1,11.957,-15.649,F,0.24,0.006,gamb_colu,intermediate,False,True,False,False
+AJ0154-C,10GBS_1208,AG1000G-GW,Guinea-Bissau,Safim,2010,-1,11.957,-15.649,F,0.154,0.006,gamb_colu,intermediate,False,True,False,False
+AJ0155-C,10GBS_1212,AG1000G-GW,Guinea-Bissau,Safim,2010,-1,11.957,-15.649,F,0.1,0.005,gamb_colu,gambiae,False,True,True,False
+AJ0156-C,10GBS_1214,AG1000G-GW,Guinea-Bissau,Safim,2010,-1,11.957,-15.649,F,0.169,0.007,gamb_colu,intermediate,False,True,False,False
+AJ0157-C,10GBS_1215,AG1000G-GW,Guinea-Bissau,Safim,2010,-1,11.957,-15.649,F,0.15,0.006,gamb_colu,intermediate,False,True,False,False
+AJ0158-C,10GBS_1221,AG1000G-GW,Guinea-Bissau,Safim,2010,-1,11.957,-15.649,F,0.333,0.005,gamb_colu,intermediate,False,True,False,False
+AJ0159-C,10GBS_1229,AG1000G-GW,Guinea-Bissau,Safim,2010,-1,11.957,-15.649,F,0.128,0.006,gamb_colu,intermediate,False,True,False,False
+AJ0161-C,10GBS_1237,AG1000G-GW,Guinea-Bissau,Safim,2010,-1,11.957,-15.649,F,0.174,0.006,gamb_colu,intermediate,False,True,False,False
+AJ0028-C,BIS006,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.134,0.005,gamb_colu,intermediate,False,True,False,False
+AJ0038-C,BIS016,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.085,0.006,gamb_colu,gambiae,False,True,True,False
+AJ0049-C,BIS027,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.085,0.006,gamb_colu,gambiae,False,True,True,False
+AJ0060-C,BIS038,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.143,0.006,gamb_colu,intermediate,False,True,False,False
+AJ0068-C,BIS046,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.321,0.006,gamb_colu,intermediate,False,True,False,False
+AJ0080-C,BIS058,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.294,0.005,gamb_colu,intermediate,False,True,False,False
+AJ0087-C,BIS065,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.376,0.006,gamb_colu,intermediate,False,True,False,False
+AJ0119-C,BIS097,AG1000G-GW,Guinea-Bissau,Antula,2010,-1,11.891,-15.582,F,0.154,0.006,gamb_colu,intermediate,False,True,False,False
+AK0041-C,KIL52,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.451,0.742,arabiensis,,True,False,False,False
+AK0042-C,KIL53,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.453,0.742,arabiensis,,True,False,False,False
+AK0043-C,KIL54,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.454,0.744,arabiensis,,True,False,False,False
+AK0044-C,KIL55,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.454,0.743,arabiensis,,True,False,False,False
+AK0046-C,KIL35,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.458,0.745,arabiensis,,True,False,False,False
+AK0047-C,KIL36,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.453,0.744,arabiensis,,True,False,False,False
+AK0049-C,KIL38,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.32,0.004,gamb_colu,intermediate,False,True,False,False
+AK0050-C,KIL39,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.133,0.004,gamb_colu,intermediate,False,True,False,False
+AK0051-C,KIL40,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.157,0.003,gamb_colu,intermediate,False,True,False,False
+AK0052-C,KIL41,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.222,0.004,gamb_colu,intermediate,False,True,False,False
+AK0054-C,KIL43,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.456,0.733,arabiensis,,True,False,False,False
+AK0055-C,KIL44,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.458,0.744,arabiensis,,True,False,False,False
+AK0056-C,KIL46,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.455,0.738,arabiensis,,True,False,False,False
+AK0062-C,KIL47,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.068,0.003,gamb_colu,gambiae,False,True,True,False
+AK0063-C,KIL1,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.099,0.003,gamb_colu,gambiae,False,True,True,False
+AK0065-C,KIL3,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.276,0.005,gamb_colu,intermediate,False,True,False,False
+AK0067-C,KIL5,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.229,0.004,gamb_colu,intermediate,False,True,False,False
+AK0068-C,KIL6,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.33,0.004,gamb_colu,intermediate,False,True,False,False
+AK0069-C,KIL7,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.309,0.004,gamb_colu,intermediate,False,True,False,False
+AK0070-C,KIL8,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.153,0.004,gamb_colu,intermediate,False,True,False,False
+AK0071-C,KIL9,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.224,0.004,gamb_colu,intermediate,False,True,False,False
+AK0072-C,KIL10,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.346,0.003,gamb_colu,intermediate,False,True,False,False
+AK0073-C,KIL11,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.186,0.004,gamb_colu,intermediate,False,True,False,False
+AK0076-C,KIL14,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.235,0.005,gamb_colu,intermediate,False,True,False,False
+AK0077-C,KIL15,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.237,0.003,gamb_colu,intermediate,False,True,False,False
+AK0078-C,KIL16,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.199,0.004,gamb_colu,intermediate,False,True,False,False
+AK0079-C,KIL17,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.168,0.005,gamb_colu,intermediate,False,True,False,False
+AK0081-C,KIL19,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.203,0.003,gamb_colu,intermediate,False,True,False,False
+AK0082-C,KIL20,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.196,0.003,gamb_colu,intermediate,False,True,False,False
+AK0083-C,KIL21,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.201,0.004,gamb_colu,intermediate,False,True,False,False
+AK0085-C,KIL23,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.215,0.005,gamb_colu,intermediate,False,True,False,False
+AK0086-C,KIL24,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.138,0.004,gamb_colu,intermediate,False,True,False,False
+AK0087-C,KIL25,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.146,0.004,gamb_colu,intermediate,False,True,False,False
+AK0088-C,KIL26,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.105,0.003,gamb_colu,gambiae,False,True,True,False
+AK0089-C,KIL27,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.196,0.005,gamb_colu,intermediate,False,True,False,False
+AK0091-C,KIL29,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.163,0.004,gamb_colu,intermediate,False,True,False,False
+AK0093-C,KIL31,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.253,0.004,gamb_colu,intermediate,False,True,False,False
+AK0094-C,KIL32,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.182,0.004,gamb_colu,intermediate,False,True,False,False
+AK0095-C,KIL33,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.233,0.003,gamb_colu,intermediate,False,True,False,False
+AK0096-C,KIL56,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.299,0.003,gamb_colu,intermediate,False,True,False,False
+AK0098-C,KIL58,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.335,0.004,gamb_colu,intermediate,False,True,False,False
+AK0099-C,KIL59,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.115,0.004,gamb_colu,gambiae,False,True,True,False
+AK0101-C,KIL61,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.165,0.004,gamb_colu,intermediate,False,True,False,False
+AK0102-C,KIL62,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.106,0.004,gamb_colu,gambiae,False,True,True,False
+AK0104-C,KIL64,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.125,0.004,gamb_colu,intermediate,False,True,False,False
+AK0105-C,KIL65,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.242,0.003,gamb_colu,intermediate,False,True,False,False
+AK0106-C,KIL66,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.073,0.004,gamb_colu,gambiae,False,True,True,False
+AK0107-C,KIL67,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.215,0.004,gamb_colu,intermediate,False,True,False,False
+AK0108-C,KIL68,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.129,0.005,gamb_colu,intermediate,False,True,False,False
+AK0110-C,KIL70,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.182,0.004,gamb_colu,intermediate,False,True,False,False
+AK0116-C,KIL76,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.096,0.004,gamb_colu,gambiae,False,True,True,False
+AK0117-C,KIL77,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.252,0.005,gamb_colu,intermediate,False,True,False,False
+AK0119-C,KIL79,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.25,0.002,gamb_colu,intermediate,False,True,False,False
+AK0127-C,KIL86b,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.137,0.004,gamb_colu,intermediate,False,True,False,False
+AK0045-Cx,KIL34,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.115,0.003,gamb_colu,gambiae,False,True,True,False
+AK0057-Cx,KIL48,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.46,0.748,arabiensis,,True,False,False,False
+AK0060-C,KIL51,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.223,0.004,gamb_colu,intermediate,False,True,False,False
+AK0066-Cx,KIL4,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.276,0.004,gamb_colu,intermediate,False,True,False,False
+AK0075-Cx,KIL13,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.313,0.003,gamb_colu,intermediate,False,True,False,False
+AK0090-Cx,KIL28,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.127,0.003,gamb_colu,intermediate,False,True,False,False
+AK0092-Cx,KIL30,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.193,0.003,gamb_colu,intermediate,False,True,False,False
+AK0100-Cx,KIL60,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.166,0.004,gamb_colu,intermediate,False,True,False,False
+AK0103-Cx,KIL63,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.199,0.004,gamb_colu,intermediate,False,True,False,False
+AK0109-Cx,KIL69,AG1000G-KE,Kenya,Kilifi,2012,-1,-3.511,39.909,F,0.105,0.004,gamb_colu,gambiae,False,True,True,False
+AK0177-C,K1,AG1000G-KE,Kenya,Kilifi,2000,-1,-3.511,39.909,F,0.037,0.002,gamb_colu,gambiae,False,True,True,False
+AK0203-C,K247,AG1000G-KE,Kenya,Kilifi,2000,-1,-3.511,39.909,M,0.036,0.002,gamb_colu,gambiae,False,True,True,False
+AK0207-C,K251,AG1000G-KE,Kenya,Kilifi,2000,-1,-3.511,39.909,M,0.04,0.002,gamb_colu,gambiae,False,True,True,False
+AK0211-C,K259,AG1000G-KE,Kenya,Kilifi,2000,-1,-3.511,39.909,M,0.038,0.003,gamb_colu,gambiae,False,True,True,False
+AK0212-C,K264,AG1000G-KE,Kenya,Kilifi,2000,-1,-3.511,39.909,M,0.044,0.002,gamb_colu,gambiae,False,True,True,False
+AK0213-C,K265,AG1000G-KE,Kenya,Kilifi,2000,-1,-3.511,39.909,F,0.038,0.002,gamb_colu,gambiae,False,True,True,False
+AK0214-C,K266,AG1000G-KE,Kenya,Kilifi,2000,-1,-3.511,39.909,M,0.044,0.003,gamb_colu,gambiae,False,True,True,False
+AK0215-C,K267,AG1000G-KE,Kenya,Kilifi,2000,-1,-3.511,39.909,M,0.038,0.003,gamb_colu,gambiae,False,True,True,False
+AK0226-C,K395,AG1000G-KE,Kenya,Kilifi,2000,-1,-3.511,39.909,M,0.042,0.003,gamb_colu,gambiae,False,True,True,False
+AK0235-C,K422,AG1000G-KE,Kenya,Kilifi,2000,-1,-3.511,39.909,F,0.04,0.002,gamb_colu,gambiae,False,True,True,False
+AK0236-C,K424,AG1000G-KE,Kenya,Kilifi,2000,-1,-3.511,39.909,M,0.029,0.003,gamb_colu,gambiae,False,True,True,False
+AK0237-C,K425,AG1000G-KE,Kenya,Kilifi,2000,-1,-3.511,39.909,F,0.048,0.002,gamb_colu,gambiae,False,True,True,False
+AK0238-C,K426,AG1000G-KE,Kenya,Kilifi,2000,-1,-3.511,39.909,F,0.036,0.002,gamb_colu,gambiae,False,True,True,False
+AK0239-C,K427,AG1000G-KE,Kenya,Kilifi,2000,-1,-3.511,39.909,F,0.038,0.002,gamb_colu,gambiae,False,True,True,False
+AK0274-C,K585,AG1000G-KE,Kenya,Kilifi,2000,-1,-3.511,39.909,F,0.044,0.002,gamb_colu,gambiae,False,True,True,False
+AK0278-C,K590,AG1000G-KE,Kenya,Kilifi,2000,-1,-3.511,39.909,M,0.044,0.002,gamb_colu,gambiae,False,True,True,False
+AK0279-C,K626,AG1000G-KE,Kenya,Kilifi,2000,-1,-3.511,39.909,M,0.028,0.003,gamb_colu,gambiae,False,True,True,False
+AK0280-C,K630,AG1000G-KE,Kenya,Kilifi,2000,-1,-3.511,39.909,F,0.034,0.002,gamb_colu,gambiae,False,True,True,False
+AK0281-C,K631,AG1000G-KE,Kenya,Kilifi,2000,-1,-3.511,39.909,M,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+AK0284-C,GF989,AG1000G-KE,Kenya,Kilifi,2007,-1,-3.511,39.909,F,0.465,0.614,arabiensis,,True,False,False,False
+AK0298-C,GF1013,AG1000G-KE,Kenya,Kilifi,2007,-1,-3.511,39.909,F,0.457,0.722,arabiensis,,True,False,False,False
+AK0299-C,GF1014,AG1000G-KE,Kenya,Kilifi,2007,-1,-3.511,39.909,F,0.46,0.661,arabiensis,,True,False,False,False
+AZ0292-C,MA7-36,AG1000G-ML-A,Mali,Kababougou,2014,8,12.89,-8.15,F,0.984,0.002,gamb_colu,coluzzii,False,True,False,True
+AZ0293-C,MA7-37,AG1000G-ML-A,Mali,Kababougou,2014,8,12.89,-8.15,F,0.982,0.002,gamb_colu,coluzzii,False,True,False,True
+AZ0294-C,MA7-4,AG1000G-ML-A,Mali,Kababougou,2014,8,12.89,-8.15,F,0.982,0.002,gamb_colu,coluzzii,False,True,False,True
+AZ0295-C,MA7-41,AG1000G-ML-A,Mali,Kababougou,2014,8,12.89,-8.15,F,0.98,0.002,gamb_colu,coluzzii,False,True,False,True
+AZ0296-C,MA7-44,AG1000G-ML-A,Mali,Kababougou,2014,8,12.89,-8.15,F,0.989,0.002,gamb_colu,coluzzii,False,True,False,True
+AZ0297-C,MA7-7,AG1000G-ML-A,Mali,Kababougou,2014,8,12.89,-8.15,F,0.983,0.002,gamb_colu,coluzzii,False,True,False,True
+AZ0298-C,MA7-8,AG1000G-ML-A,Mali,Kababougou,2014,8,12.89,-8.15,F,0.983,0.002,gamb_colu,coluzzii,False,True,False,True
+AZ0300-C,MA4-2,AG1000G-ML-A,Mali,Kababougou,2014,8,12.89,-8.15,F,0.032,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0301-C,MA4-3,AG1000G-ML-A,Mali,Kababougou,2014,8,12.89,-8.15,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0302-C,MA4-4,AG1000G-ML-A,Mali,Kababougou,2014,8,12.89,-8.15,F,0.028,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0304-C,MA4-8,AG1000G-ML-A,Mali,Kababougou,2014,8,12.89,-8.15,F,0.015,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0305-C,MA6-1,AG1000G-ML-A,Mali,Kababougou,2014,8,12.89,-8.15,M,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0306-C,MA6-10,AG1000G-ML-A,Mali,Kababougou,2014,8,12.89,-8.15,F,0.061,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0307-C,MA6-18,AG1000G-ML-A,Mali,Kababougou,2014,8,12.89,-8.15,F,0.028,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0308-C,MA6-2,AG1000G-ML-A,Mali,Kababougou,2014,8,12.89,-8.15,M,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0309-C,MA6-20,AG1000G-ML-A,Mali,Kababougou,2014,8,12.89,-8.15,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0310-C,MA6-27,AG1000G-ML-A,Mali,Kababougou,2014,8,12.89,-8.15,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0311-C,MA6-29,AG1000G-ML-A,Mali,Kababougou,2014,8,12.89,-8.15,F,0.019,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0313-C,MA6-36,AG1000G-ML-A,Mali,Kababougou,2014,8,12.89,-8.15,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0314-C,MA6-37,AG1000G-ML-A,Mali,Kababougou,2014,8,12.89,-8.15,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0316-C,MA6-43,AG1000G-ML-A,Mali,Kababougou,2014,8,12.89,-8.15,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0317-C,MA6-44,AG1000G-ML-A,Mali,Kababougou,2014,8,12.89,-8.15,F,0.02,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0318-C,MA6-47,AG1000G-ML-A,Mali,Kababougou,2014,8,12.89,-8.15,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0319-C,MA6-9,AG1000G-ML-A,Mali,Kababougou,2014,8,12.89,-8.15,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0320-C,MA4-1,AG1000G-ML-A,Mali,Kababougou,2014,8,12.89,-8.15,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0321-C,MA4-5,AG1000G-ML-A,Mali,Kababougou,2014,8,12.89,-8.15,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0322-C,MA4-7,AG1000G-ML-A,Mali,Kababougou,2014,8,12.89,-8.15,F,0.043,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0323-C,MA4-9,AG1000G-ML-A,Mali,Kababougou,2014,8,12.89,-8.15,F,0.033,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0325-C,MA4-11,AG1000G-ML-A,Mali,Kababougou,2014,8,12.89,-8.15,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0326-C,MA4-12,AG1000G-ML-A,Mali,Kababougou,2014,8,12.89,-8.15,M,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0328-C,MA4-14,AG1000G-ML-A,Mali,Kababougou,2014,8,12.89,-8.15,M,0.033,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0329-C,MA4-15,AG1000G-ML-A,Mali,Kababougou,2014,8,12.89,-8.15,M,0.037,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0330-C,MA4-16,AG1000G-ML-A,Mali,Kababougou,2014,8,12.89,-8.15,M,0.03,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0331-C,MA4-17,AG1000G-ML-A,Mali,Kababougou,2014,8,12.89,-8.15,M,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0332-C,MA12-12,AG1000G-ML-A,Mali,Ouassorola,2014,8,12.9,-8.16,F,0.965,0.002,gamb_colu,coluzzii,False,True,False,True
+AZ0333-C,MA12-8,AG1000G-ML-A,Mali,Ouassorola,2014,8,12.9,-8.16,F,0.968,0.002,gamb_colu,coluzzii,False,True,False,True
+AZ0284-C,MA7-1,AG1000G-ML-A,Mali,Kababougou,2014,8,12.89,-8.15,F,0.968,0.002,gamb_colu,coluzzii,False,True,False,True
+AZ0287-C,MA7-17,AG1000G-ML-A,Mali,Kababougou,2014,8,12.89,-8.15,F,0.987,0.002,gamb_colu,coluzzii,False,True,False,True
+AZ0289-C,MA7-27,AG1000G-ML-A,Mali,Kababougou,2014,8,12.89,-8.15,F,0.976,0.002,gamb_colu,coluzzii,False,True,False,True
+AZ0290-C,MA7-28,AG1000G-ML-A,Mali,Kababougou,2014,8,12.89,-8.15,F,0.975,0.002,gamb_colu,coluzzii,False,True,False,True
+AZ0291-C,MA7-30,AG1000G-ML-A,Mali,Kababougou,2014,8,12.89,-8.15,F,0.98,0.002,gamb_colu,coluzzii,False,True,False,True
+AZ0312-C,MA6-32,AG1000G-ML-A,Mali,Kababougou,2014,8,12.89,-8.15,M,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0334-C,MA13-1,AG1000G-ML-A,Mali,Ouassorola,2014,8,12.9,-8.16,F,0.978,0.002,gamb_colu,coluzzii,False,True,False,True
+AZ0336-C,MA13-24,AG1000G-ML-A,Mali,Ouassorola,2014,8,12.9,-8.16,F,0.02,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0337-C,MA13-26,AG1000G-ML-A,Mali,Ouassorola,2014,8,12.9,-8.16,F,0.036,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0338-C,MA13-28,AG1000G-ML-A,Mali,Ouassorola,2014,8,12.9,-8.16,F,0.062,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0339-C,MA13-29,AG1000G-ML-A,Mali,Ouassorola,2014,8,12.9,-8.16,F,0.979,0.002,gamb_colu,coluzzii,False,True,False,True
+AZ0340-C,MA13-33,AG1000G-ML-A,Mali,Ouassorola,2014,8,12.9,-8.16,F,0.972,0.002,gamb_colu,coluzzii,False,True,False,True
+AZ0341-C,MA13-39,AG1000G-ML-A,Mali,Ouassorola,2014,8,12.9,-8.16,F,0.977,0.002,gamb_colu,coluzzii,False,True,False,True
+AZ0342-C,MA13-43,AG1000G-ML-A,Mali,Ouassorola,2014,8,12.9,-8.16,F,0.971,0.002,gamb_colu,coluzzii,False,True,False,True
+AZ0343-C,MA13-45,AG1000G-ML-A,Mali,Ouassorola,2014,8,12.9,-8.16,F,0.988,0.002,gamb_colu,coluzzii,False,True,False,True
+AZ0344-C,MA13-5,AG1000G-ML-A,Mali,Ouassorola,2014,8,12.9,-8.16,F,0.962,0.002,gamb_colu,coluzzii,False,True,False,True
+AZ0350-C,MA2-17,AG1000G-ML-A,Mali,Ouassorola,2014,8,12.9,-8.16,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0425-CW,MA10-46,AG1000G-ML-A,Mali,Tieneguebougou,2014,8,12.81,-8.08,F,0.967,0.003,gamb_colu,coluzzii,False,True,False,True
+AZ0433-CW,MA11-13,AG1000G-ML-A,Mali,Tieneguebougou,2014,8,12.81,-8.08,F,0.966,0.002,gamb_colu,coluzzii,False,True,False,True
+AZ0434-CW,MA11-14,AG1000G-ML-A,Mali,Tieneguebougou,2014,8,12.81,-8.08,F,0.971,0.003,gamb_colu,coluzzii,False,True,False,True
+AZ0416-CW,MA10-32,AG1000G-ML-A,Mali,Tieneguebougou,2014,8,12.81,-8.08,F,0.966,0.002,gamb_colu,coluzzii,False,True,False,True
+AZ0444-CW,MA11-28,AG1000G-ML-A,Mali,Tieneguebougou,2014,8,12.81,-8.08,F,0.967,0.002,gamb_colu,coluzzii,False,True,False,True
+AZ0484-CW,MA3-1,AG1000G-ML-A,Mali,Tieneguebougou,2014,8,12.81,-8.08,M,0.03,0.003,gamb_colu,gambiae,False,True,True,False
+AZ0459-CW,MA11-9,AG1000G-ML-A,Mali,Tieneguebougou,2014,8,12.81,-8.08,F,0.983,0.002,gamb_colu,coluzzii,False,True,False,True
+AZ0253-C,bc017,AG1000G-ML-B,Mali,Bancoumana,2004,8,12.2,-8.2,F,0.034,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0254-C,bc047,AG1000G-ML-B,Mali,Bancoumana,2004,8,12.2,-8.2,F,0.04,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0255-C,bc049,AG1000G-ML-B,Mali,Bancoumana,2004,8,12.2,-8.2,F,0.04,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0256-C,bc020,AG1000G-ML-B,Mali,Bancoumana,2004,8,12.2,-8.2,F,0.038,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0258-C,bc052,AG1000G-ML-B,Mali,Bancoumana,2004,8,12.2,-8.2,F,0.043,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0259-C,bc053,AG1000G-ML-B,Mali,Bancoumana,2004,8,12.2,-8.2,F,0.05,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0260-C,bc079,AG1000G-ML-B,Mali,Bancoumana,2004,8,12.2,-8.2,F,0.048,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0261-C,bc080,AG1000G-ML-B,Mali,Bancoumana,2004,8,12.2,-8.2,F,0.107,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0263-C,kl0890,AG1000G-ML-B,Mali,Kela,2004,8,11.88,-8.45,F,0.045,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0267-C,fz029,AG1000G-ML-B,Mali,Fanzana,2004,8,13.2,-6.13,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0268-C,fz034,AG1000G-ML-B,Mali,Fanzana,2004,8,13.2,-6.13,F,0.985,0.002,gamb_colu,coluzzii,False,True,False,True
+AZ0269-C,fz012,AG1000G-ML-B,Mali,Fanzana,2004,8,13.2,-6.13,F,0.983,0.002,gamb_colu,coluzzii,False,True,False,True
+AZ0270-C,fz045,AG1000G-ML-B,Mali,Fanzana,2004,8,13.2,-6.13,F,0.971,0.002,gamb_colu,coluzzii,False,True,False,True
+AZ0271-C,fz046,AG1000G-ML-B,Mali,Fanzana,2004,8,13.2,-6.13,F,0.987,0.002,gamb_colu,coluzzii,False,True,False,True
+AZ0272-C,mb083,AG1000G-ML-B,Mali,Moribobougou,2004,8,12.69,-7.87,F,0.98,0.002,gamb_colu,coluzzii,False,True,False,True
+AZ0273-C,mb089,AG1000G-ML-B,Mali,Moribobougou,2004,8,12.69,-7.87,F,0.977,0.002,gamb_colu,coluzzii,False,True,False,True
+AZ0274-C,mb095,AG1000G-ML-B,Mali,Moribobougou,2004,8,12.69,-7.87,F,0.982,0.002,gamb_colu,coluzzii,False,True,False,True
+AZ0275-C,mb100,AG1000G-ML-B,Mali,Moribobougou,2004,8,12.69,-7.87,F,0.987,0.002,gamb_colu,coluzzii,False,True,False,True
+AZ0276-C,mb101,AG1000G-ML-B,Mali,Moribobougou,2004,8,12.69,-7.87,F,0.979,0.002,gamb_colu,coluzzii,False,True,False,True
+AZ0277-C,mb102,AG1000G-ML-B,Mali,Moribobougou,2004,8,12.69,-7.87,F,0.977,0.002,gamb_colu,coluzzii,False,True,False,True
+AZ0278-C,mb103,AG1000G-ML-B,Mali,Moribobougou,2004,8,12.69,-7.87,F,0.987,0.002,gamb_colu,coluzzii,False,True,False,True
+AZ0279-C,kl0827,AG1000G-ML-B,Mali,Kela,2004,8,11.88,-8.45,F,0.077,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0280-C,dn061,AG1000G-ML-B,Mali,Douna,2004,8,13.21,-5.9,F,0.974,0.002,gamb_colu,coluzzii,False,True,False,True
+AZ0281-C,dn054,AG1000G-ML-B,Mali,Douna,2004,8,13.21,-5.9,F,0.987,0.002,gamb_colu,coluzzii,False,True,False,True
+AZ0282-C,dn031,AG1000G-ML-B,Mali,Douna,2004,8,13.21,-5.9,F,0.952,0.002,gamb_colu,coluzzii,False,True,False,True
+AZ0283-C,bc023,AG1000G-ML-B,Mali,Bancoumana,2004,8,12.2,-8.2,F,0.041,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02049-4431STDY6672917,DN109,AG1000G-ML-B,Mali,Douna,2004,8,13.21,-5.9,F,0.98,0.002,gamb_colu,coluzzii,False,True,False,True
+VBS02050-4431STDY6672918,DN112,AG1000G-ML-B,Mali,Douna,2004,8,13.21,-5.9,F,0.99,0.002,gamb_colu,coluzzii,False,True,False,True
+VBS02051-4431STDY6672919,ng033,AG1000G-ML-B,Mali,N'Gabakoro,2004,8,12.68,-7.84,F,0.981,0.002,gamb_colu,coluzzii,False,True,False,True
+VBS02052-4431STDY6672920,DN084,AG1000G-ML-B,Mali,Douna,2004,8,13.21,-5.9,F,0.98,0.002,gamb_colu,coluzzii,False,True,False,True
+VBS02054-4431STDY6672922,DN101,AG1000G-ML-B,Mali,Douna,2004,8,13.21,-5.9,F,0.991,0.002,gamb_colu,coluzzii,False,True,False,True
+VBS02055-4431STDY6672923,ng026,AG1000G-ML-B,Mali,N'Gabakoro,2004,8,12.68,-7.84,F,0.986,0.002,gamb_colu,coluzzii,False,True,False,True
+VBS02056-4431STDY6672924,DN087,AG1000G-ML-B,Mali,Douna,2004,8,13.21,-5.9,F,0.467,0.697,arabiensis,,True,False,False,False
+VBS02057-4431STDY6672925,fz024,AG1000G-ML-B,Mali,Fanzana,2004,8,13.2,-6.13,F,0.991,0.003,gamb_colu,coluzzii,False,True,False,True
+VBS02058-4431STDY6672926,DN111,AG1000G-ML-B,Mali,Douna,2004,8,13.21,-5.9,F,0.989,0.002,gamb_colu,coluzzii,False,True,False,True
+VBS02059-4431STDY6672927,ng003,AG1000G-ML-B,Mali,N'Gabakoro,2004,8,12.68,-7.84,F,0.983,0.002,gamb_colu,coluzzii,False,True,False,True
+VBS02060-4431STDY6672928,ng012,AG1000G-ML-B,Mali,N'Gabakoro,2004,8,12.68,-7.84,F,0.987,0.002,gamb_colu,coluzzii,False,True,False,True
+VBS02061-4431STDY6672929,fz001,AG1000G-ML-B,Mali,Fanzana,2004,8,13.2,-6.13,F,0.466,0.709,arabiensis,,True,False,False,False
+VBS02062-4431STDY6672930,fz052,AG1000G-ML-B,Mali,Fanzana,2004,8,13.2,-6.13,F,0.987,0.002,gamb_colu,coluzzii,False,True,False,True
+VBS02063-4431STDY6672931,DN076,AG1000G-ML-B,Mali,Douna,2004,8,13.21,-5.9,F,0.981,0.002,gamb_colu,coluzzii,False,True,False,True
+VBS02064-4431STDY6672932,DN078,AG1000G-ML-B,Mali,Douna,2004,8,13.21,-5.9,F,0.983,0.002,gamb_colu,coluzzii,False,True,False,True
+VBS02065-4431STDY6672933,DN080,AG1000G-ML-B,Mali,Douna,2004,8,13.21,-5.9,F,0.984,0.003,gamb_colu,coluzzii,False,True,False,True
+VBS02066-4431STDY6672934,DN083,AG1000G-ML-B,Mali,Douna,2004,8,13.21,-5.9,F,0.98,0.002,gamb_colu,coluzzii,False,True,False,True
+VBS02067-4431STDY6672935,DN085,AG1000G-ML-B,Mali,Douna,2004,8,13.21,-5.9,F,0.982,0.002,gamb_colu,coluzzii,False,True,False,True
+VBS02068-4431STDY6672936,DN086,AG1000G-ML-B,Mali,Douna,2004,8,13.21,-5.9,F,0.985,0.002,gamb_colu,coluzzii,False,True,False,True
+VBS02069-4431STDY6672937,DN088,AG1000G-ML-B,Mali,Douna,2004,8,13.21,-5.9,F,0.984,0.002,gamb_colu,coluzzii,False,True,False,True
+VBS02070-4431STDY6672938,DN089,AG1000G-ML-B,Mali,Douna,2004,8,13.21,-5.9,F,0.983,0.002,gamb_colu,coluzzii,False,True,False,True
+VBS02071-4431STDY6672939,DN091,AG1000G-ML-B,Mali,Douna,2004,8,13.21,-5.9,F,0.979,0.002,gamb_colu,coluzzii,False,True,False,True
+VBS02072-4431STDY6672940,DN092,AG1000G-ML-B,Mali,Douna,2004,8,13.21,-5.9,F,0.981,0.002,gamb_colu,coluzzii,False,True,False,True
+VBS02073-4431STDY6672941,DN095,AG1000G-ML-B,Mali,Douna,2004,8,13.21,-5.9,F,0.984,0.002,gamb_colu,coluzzii,False,True,False,True
+VBS02077-4431STDY6772805,kl0071,AG1000G-ML-B,Mali,Kela,2004,8,11.88,-8.45,F,0.048,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02083-4431STDY6772806,kl0107,AG1000G-ML-B,Mali,Kela,2004,8,11.88,-8.45,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02088-4431STDY6772808,kl0152,AG1000G-ML-B,Mali,Kela,2004,8,11.88,-8.45,F,0.043,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02090-4431STDY6772809,kl0174,AG1000G-ML-B,Mali,Kela,2004,8,11.88,-8.45,F,0.041,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02093-4431STDY6772811,kl0183,AG1000G-ML-B,Mali,Kela,2004,8,11.88,-8.45,F,0.028,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02094-4431STDY6772812,kl0185,AG1000G-ML-B,Mali,Kela,2004,8,11.88,-8.45,F,0.035,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02095-4431STDY6772813,kl0214,AG1000G-ML-B,Mali,Kela,2004,8,11.88,-8.45,F,0.053,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02097-4431STDY6772815,kl0223,AG1000G-ML-B,Mali,Kela,2004,8,11.88,-8.45,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02101-4431STDY6772818,kl0315,AG1000G-ML-B,Mali,Kela,2004,8,11.88,-8.45,F,0.042,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02103-4431STDY6772819,kl0351,AG1000G-ML-B,Mali,Kela,2004,8,11.88,-8.45,F,0.041,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02104-4431STDY6772820,kl0357,AG1000G-ML-B,Mali,Kela,2004,8,11.88,-8.45,F,0.072,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02106-4431STDY6772821,kl0364,AG1000G-ML-B,Mali,Kela,2004,8,11.88,-8.45,F,0.072,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02107-4431STDY6772822,kl0371,AG1000G-ML-B,Mali,Kela,2004,8,11.88,-8.45,F,0.037,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02109-4431STDY6772823,kl0647,AG1000G-ML-B,Mali,Kela,2004,8,11.88,-8.45,F,0.038,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02110-4431STDY6772824,kl0649,AG1000G-ML-B,Mali,Kela,2004,8,11.88,-8.45,F,0.062,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02112-4431STDY6772826,kl0663,AG1000G-ML-B,Mali,Kela,2004,8,11.88,-8.45,F,0.081,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02119-4431STDY6772831,kl0831,AG1000G-ML-B,Mali,Kela,2004,8,11.88,-8.45,F,0.028,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02121-4431STDY6772832,kl0836,AG1000G-ML-B,Mali,Kela,2004,8,11.88,-8.45,F,0.046,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02127-4431STDY6772833,kl0869,AG1000G-ML-B,Mali,Kela,2004,8,11.88,-8.45,F,0.037,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02129-4431STDY6772835,kl0884,AG1000G-ML-B,Mali,Kela,2004,8,11.88,-8.45,F,0.033,0.002,gamb_colu,gambiae,False,True,True,False
+VBS02130-4431STDY6772836,kl0886,AG1000G-ML-B,Mali,Kela,2004,8,11.88,-8.45,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AZ0152-C,ME234D,AG1000G-MW,Malawi,Chikhwawa,2015,5,-15.933,34.755,F,0.455,0.747,arabiensis,,True,False,False,False
+AZ0153-C,ME234E,AG1000G-MW,Malawi,Chikhwawa,2015,5,-15.933,34.755,F,0.457,0.75,arabiensis,,True,False,False,False
+AZ0155-C,ME234G,AG1000G-MW,Malawi,Chikhwawa,2015,5,-15.933,34.755,F,0.458,0.751,arabiensis,,True,False,False,False
+AZ0156-C,ME234H,AG1000G-MW,Malawi,Chikhwawa,2015,5,-15.933,34.755,F,0.457,0.748,arabiensis,,True,False,False,False
+AZ0157-C,ME234J,AG1000G-MW,Malawi,Chikhwawa,2015,5,-15.933,34.755,F,0.458,0.75,arabiensis,,True,False,False,False
+AZ0158-C,ME234K,AG1000G-MW,Malawi,Chikhwawa,2015,5,-15.933,34.755,F,0.453,0.749,arabiensis,,True,False,False,False
+AZ0159-C,ME234O,AG1000G-MW,Malawi,Chikhwawa,2015,5,-15.933,34.755,F,0.456,0.75,arabiensis,,True,False,False,False
+AZ0160-C,ME234P,AG1000G-MW,Malawi,Chikhwawa,2015,5,-15.933,34.755,F,0.462,0.749,arabiensis,,True,False,False,False
+AZ0161-C,ME234R,AG1000G-MW,Malawi,Chikhwawa,2015,5,-15.933,34.755,F,0.459,0.75,arabiensis,,True,False,False,False
+AZ0164-C,ME234X,AG1000G-MW,Malawi,Chikhwawa,2015,5,-15.933,34.755,F,0.458,0.75,arabiensis,,True,False,False,False
+AZ0165-C,ME234Z,AG1000G-MW,Malawi,Chikhwawa,2015,5,-15.933,34.755,F,0.458,0.751,arabiensis,,True,False,False,False
+AZ0166-C,ME2352,AG1000G-MW,Malawi,Chikhwawa,2015,5,-15.933,34.755,F,0.459,0.751,arabiensis,,True,False,False,False
+AZ0167-C,ME2355,AG1000G-MW,Malawi,Chikhwawa,2015,5,-15.933,34.755,F,0.455,0.749,arabiensis,,True,False,False,False
+AZ0168-C,ME2356,AG1000G-MW,Malawi,Chikhwawa,2015,5,-15.933,34.755,F,0.459,0.75,arabiensis,,True,False,False,False
+AZ0170-C,ME235A,AG1000G-MW,Malawi,Chikhwawa,2015,5,-15.933,34.755,F,0.456,0.751,arabiensis,,True,False,False,False
+AZ0172-C,ME235C,AG1000G-MW,Malawi,Chikhwawa,2015,5,-15.933,34.755,F,0.457,0.75,arabiensis,,True,False,False,False
+AZ0174-C,ME235L,AG1000G-MW,Malawi,Chikhwawa,2015,5,-15.933,34.755,F,0.46,0.749,arabiensis,,True,False,False,False
+AZ0175-C,ME235M,AG1000G-MW,Malawi,Chikhwawa,2015,5,-15.933,34.755,F,0.455,0.752,arabiensis,,True,False,False,False
+AZ0176-C,ME235N,AG1000G-MW,Malawi,Chikhwawa,2015,5,-15.933,34.755,F,0.459,0.75,arabiensis,,True,False,False,False
+AZ0179-C,ME2367,AG1000G-MW,Malawi,Chikhwawa,2015,5,-15.933,34.755,F,0.454,0.75,arabiensis,,True,False,False,False
+AZ0180-C,ME2368,AG1000G-MW,Malawi,Chikhwawa,2015,5,-15.933,34.755,F,0.459,0.75,arabiensis,,True,False,False,False
+AZ0181-C,ME2369,AG1000G-MW,Malawi,Chikhwawa,2015,5,-15.933,34.755,F,0.46,0.75,arabiensis,,True,False,False,False
+AZ0182-C,ME236A,AG1000G-MW,Malawi,Chikhwawa,2015,5,-15.933,34.755,F,0.456,0.751,arabiensis,,True,False,False,False
+AZ0183-C,ME236B,AG1000G-MW,Malawi,Chikhwawa,2015,5,-15.933,34.755,F,0.459,0.75,arabiensis,,True,False,False,False
+AZ0184-C,ME236C,AG1000G-MW,Malawi,Chikhwawa,2015,5,-15.933,34.755,F,0.456,0.75,arabiensis,,True,False,False,False
+AZ0185-C,ME236E,AG1000G-MW,Malawi,Chikhwawa,2015,5,-15.933,34.755,F,0.455,0.75,arabiensis,,True,False,False,False
+AZ0186-C,ME236K,AG1000G-MW,Malawi,Chikhwawa,2015,5,-15.933,34.755,F,0.454,0.75,arabiensis,,True,False,False,False
+AZ0187-C,ME236P,AG1000G-MW,Malawi,Chikhwawa,2015,5,-15.933,34.755,F,0.456,0.749,arabiensis,,True,False,False,False
+AZ0188-C,ME236Q,AG1000G-MW,Malawi,Chikhwawa,2015,5,-15.933,34.755,F,0.46,0.75,arabiensis,,True,False,False,False
+AZ0191-C,ME237L,AG1000G-MW,Malawi,Chikhwawa,2015,5,-15.933,34.755,F,0.46,0.749,arabiensis,,True,False,False,False
+AZ0192-C,ME237M,AG1000G-MW,Malawi,Chikhwawa,2015,5,-15.933,34.755,F,0.457,0.75,arabiensis,,True,False,False,False
+AZ0199-C,ME237X,AG1000G-MW,Malawi,Chikhwawa,2015,5,-15.933,34.755,F,0.459,0.75,arabiensis,,True,False,False,False
+AZ0200-C,ME237Y,AG1000G-MW,Malawi,Chikhwawa,2015,5,-15.933,34.755,F,0.461,0.75,arabiensis,,True,False,False,False
+AZ0201-C,ME237Z,AG1000G-MW,Malawi,Chikhwawa,2015,5,-15.933,34.755,F,0.452,0.75,arabiensis,,True,False,False,False
+AZ0202-C,ME2382,AG1000G-MW,Malawi,Chikhwawa,2015,5,-15.933,34.755,F,0.455,0.749,arabiensis,,True,False,False,False
+AZ0223-C,ME2345,AG1000G-MW,Malawi,Chikhwawa,2015,5,-15.933,34.755,F,0.456,0.731,arabiensis,,True,False,False,False
+AZ0226-C,ME2348,AG1000G-MW,Malawi,Chikhwawa,2015,5,-15.933,34.755,F,0.45,0.728,arabiensis,,True,False,False,False
+AZ0242-C,ME232M,AG1000G-MW,Malawi,Chikhwawa,2015,5,-15.933,34.755,F,0.433,0.719,arabiensis,,True,False,False,False
+AZ0246-C,ME232R,AG1000G-MW,Malawi,Chikhwawa,2015,5,-15.933,34.755,F,0.439,0.686,arabiensis,,True,False,False,False
+AZ0247-C,ME232S,AG1000G-MW,Malawi,Chikhwawa,2015,5,-15.933,34.755,F,0.444,0.727,arabiensis,,True,False,False,False
+AZ0251-C,ME232W,AG1000G-MW,Malawi,Chikhwawa,2015,5,-15.933,34.755,F,0.441,0.713,arabiensis,,True,False,False,False
+BQ0046-C,1/1,AG1000G-MZ,Mozambique,Furvela,2004,2,-23.716,35.299,F,0.04,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0047-C,1/2,AG1000G-MZ,Mozambique,Furvela,2004,2,-23.716,35.299,F,0.037,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0049-C,1/4,AG1000G-MZ,Mozambique,Furvela,2004,2,-23.716,35.299,F,0.045,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0050-C,1/5,AG1000G-MZ,Mozambique,Furvela,2004,2,-23.716,35.299,F,0.04,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0051-C,1/9,AG1000G-MZ,Mozambique,Furvela,2004,2,-23.716,35.299,F,0.049,0.013,gamb_colu,gambiae,False,True,True,False
+BQ0052-C,1/10,AG1000G-MZ,Mozambique,Furvela,2004,2,-23.716,35.299,F,0.038,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0053-C,2/1,AG1000G-MZ,Mozambique,Furvela,2004,2,-23.716,35.299,F,0.04,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0054-C,2/2,AG1000G-MZ,Mozambique,Furvela,2004,2,-23.716,35.299,F,0.035,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0055-C,2/5,AG1000G-MZ,Mozambique,Furvela,2004,2,-23.716,35.299,F,0.052,0.003,gamb_colu,gambiae,False,True,True,False
+BQ0056-C,2/6,AG1000G-MZ,Mozambique,Furvela,2004,2,-23.716,35.299,F,0.034,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0057-C,2/7,AG1000G-MZ,Mozambique,Furvela,2004,2,-23.716,35.299,F,0.048,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0058-C,2/8,AG1000G-MZ,Mozambique,Furvela,2004,2,-23.716,35.299,F,0.049,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0059-C,2/9,AG1000G-MZ,Mozambique,Furvela,2004,2,-23.716,35.299,F,0.044,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0060-C,2/10,AG1000G-MZ,Mozambique,Furvela,2004,2,-23.716,35.299,F,0.045,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0062-C,3/3,AG1000G-MZ,Mozambique,Furvela,2004,3,-23.716,35.299,F,0.042,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0064-C,3/5,AG1000G-MZ,Mozambique,Furvela,2004,3,-23.716,35.299,F,0.039,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0065-C,3/6,AG1000G-MZ,Mozambique,Furvela,2004,3,-23.716,35.299,F,0.045,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0066-C,3/7,AG1000G-MZ,Mozambique,Furvela,2004,3,-23.716,35.299,F,0.037,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0067-C,3/8,AG1000G-MZ,Mozambique,Furvela,2004,3,-23.716,35.299,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0068-C,3/10,AG1000G-MZ,Mozambique,Furvela,2004,3,-23.716,35.299,F,0.036,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0069-C,4/1,AG1000G-MZ,Mozambique,Furvela,2004,2,-23.716,35.299,F,0.04,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0070-C,4/2,AG1000G-MZ,Mozambique,Furvela,2004,2,-23.716,35.299,F,0.036,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0071-C,4/3,AG1000G-MZ,Mozambique,Furvela,2004,2,-23.716,35.299,F,0.045,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0072-C,4/4,AG1000G-MZ,Mozambique,Furvela,2004,2,-23.716,35.299,F,0.042,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0073-C,4/5,AG1000G-MZ,Mozambique,Furvela,2004,2,-23.716,35.299,F,0.046,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0074-C,4/6,AG1000G-MZ,Mozambique,Furvela,2004,2,-23.716,35.299,F,0.04,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0075-C,4/7,AG1000G-MZ,Mozambique,Furvela,2004,2,-23.716,35.299,F,0.037,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0076-C,9/11,AG1000G-MZ,Mozambique,Furvela,2004,2,-23.716,35.299,F,0.04,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0077-C,10/2,AG1000G-MZ,Mozambique,Furvela,2004,3,-23.716,35.299,F,0.044,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0078-C,10/3,AG1000G-MZ,Mozambique,Furvela,2004,3,-23.716,35.299,F,0.035,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0079-C,10/4,AG1000G-MZ,Mozambique,Furvela,2004,3,-23.716,35.299,F,0.037,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0080-C,10/6,AG1000G-MZ,Mozambique,Furvela,2004,3,-23.716,35.299,F,0.041,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0081-C,10/7,AG1000G-MZ,Mozambique,Furvela,2004,3,-23.716,35.299,F,0.036,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0082-C,10/9,AG1000G-MZ,Mozambique,Furvela,2004,3,-23.716,35.299,F,0.049,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0083-C,11/1,AG1000G-MZ,Mozambique,Furvela,2004,3,-23.716,35.299,F,0.045,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0084-C,11/2,AG1000G-MZ,Mozambique,Furvela,2004,3,-23.716,35.299,F,0.038,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0085-C,11/3,AG1000G-MZ,Mozambique,Furvela,2004,3,-23.716,35.299,F,0.036,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0086-C,11/4,AG1000G-MZ,Mozambique,Furvela,2004,3,-23.716,35.299,F,0.037,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0087-C,11/5,AG1000G-MZ,Mozambique,Furvela,2004,3,-23.716,35.299,F,0.035,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0088-C,11/6,AG1000G-MZ,Mozambique,Furvela,2004,3,-23.716,35.299,F,0.04,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0089-C,11/7,AG1000G-MZ,Mozambique,Furvela,2004,3,-23.716,35.299,F,0.043,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0090-C,11/9,AG1000G-MZ,Mozambique,Furvela,2004,3,-23.716,35.299,F,0.049,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0091-C,11/10,AG1000G-MZ,Mozambique,Furvela,2004,3,-23.716,35.299,F,0.046,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0092-C,12/1,AG1000G-MZ,Mozambique,Furvela,2004,4,-23.716,35.299,F,0.042,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0093-C,12/2,AG1000G-MZ,Mozambique,Furvela,2004,4,-23.716,35.299,F,0.034,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0094-C,12/4,AG1000G-MZ,Mozambique,Furvela,2004,4,-23.716,35.299,F,0.039,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0095-C,12/5,AG1000G-MZ,Mozambique,Furvela,2004,4,-23.716,35.299,F,0.035,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0096-C,12/7,AG1000G-MZ,Mozambique,Furvela,2004,4,-23.716,35.299,F,0.045,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0097-C,12/8,AG1000G-MZ,Mozambique,Furvela,2004,4,-23.716,35.299,F,0.045,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0098-C,12/9,AG1000G-MZ,Mozambique,Furvela,2004,4,-23.716,35.299,F,0.037,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0099-C,13/1,AG1000G-MZ,Mozambique,Furvela,2004,4,-23.716,35.299,F,0.044,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0100-C,13/2,AG1000G-MZ,Mozambique,Furvela,2004,4,-23.716,35.299,F,0.037,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0102-C,13/4,AG1000G-MZ,Mozambique,Furvela,2004,4,-23.716,35.299,F,0.041,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0103-C,13/5,AG1000G-MZ,Mozambique,Furvela,2004,4,-23.716,35.299,F,0.033,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0106-C,13/8,AG1000G-MZ,Mozambique,Furvela,2004,4,-23.716,35.299,F,0.045,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0107-C,13/9,AG1000G-MZ,Mozambique,Furvela,2004,4,-23.716,35.299,F,0.045,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0108-C,13/10,AG1000G-MZ,Mozambique,Furvela,2004,4,-23.716,35.299,F,0.037,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0109-C,14/1,AG1000G-MZ,Mozambique,Furvela,2004,4,-23.716,35.299,F,0.038,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0110-C,14/2,AG1000G-MZ,Mozambique,Furvela,2004,4,-23.716,35.299,F,0.042,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0111-C,14/3,AG1000G-MZ,Mozambique,Furvela,2004,4,-23.716,35.299,F,0.054,0.01,gamb_colu,gambiae,False,True,True,False
+BQ0114-C,14/6,AG1000G-MZ,Mozambique,Furvela,2004,4,-23.716,35.299,F,0.041,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0115-C,14/7,AG1000G-MZ,Mozambique,Furvela,2004,4,-23.716,35.299,F,0.04,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0116-C,14/8,AG1000G-MZ,Mozambique,Furvela,2004,4,-23.716,35.299,F,0.04,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0117-C,14/9,AG1000G-MZ,Mozambique,Furvela,2004,4,-23.716,35.299,F,0.045,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0118-C,14/10,AG1000G-MZ,Mozambique,Furvela,2004,4,-23.716,35.299,F,0.045,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0119-C,42/8,AG1000G-MZ,Mozambique,Furvela,2004,3,-23.716,35.299,F,0.041,0.003,gamb_colu,gambiae,False,True,True,False
+BQ0120-C,42/13,AG1000G-MZ,Mozambique,Furvela,2004,3,-23.716,35.299,F,0.06,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0121-C,42/14,AG1000G-MZ,Mozambique,Furvela,2004,3,-23.716,35.299,F,0.035,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0122-C,43/2,AG1000G-MZ,Mozambique,Furvela,2003,12,-23.716,35.299,F,0.041,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0123-C,43/3,AG1000G-MZ,Mozambique,Furvela,2003,12,-23.716,35.299,F,0.052,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0125-C,43/8,AG1000G-MZ,Mozambique,Furvela,2003,12,-23.716,35.299,F,0.035,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0126-C,44/4,AG1000G-MZ,Mozambique,Furvela,2004,2,-23.716,35.299,F,0.042,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0129-C,46/7,AG1000G-MZ,Mozambique,Furvela,2004,2,-23.716,35.299,F,0.042,0.002,gamb_colu,gambiae,False,True,True,False
+BQ0130-C,46/8,AG1000G-MZ,Mozambique,Furvela,2004,2,-23.716,35.299,F,0.042,0.002,gamb_colu,gambiae,False,True,True,False
+BL0046-C,Plate_C_H6,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.125,0.005,gamb_colu,intermediate,False,True,False,False
+BL0047-C,Plate_F_D4,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.459,0.745,arabiensis,,True,False,False,False
+BL0048-C,Plate_F_E4,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.455,0.742,arabiensis,,True,False,False,False
+BL0049-C,Plate_F_F4,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.455,0.744,arabiensis,,True,False,False,False
+BL0050-C,Plate_F_G4,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.451,0.735,arabiensis,,True,False,False,False
+BL0052-C,Plate_D_1,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,M,0.041,0.015,gamb_colu,gambiae,False,True,True,False
+BL0054-C,Plate_D_B2,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.033,0.004,gamb_colu,gambiae,False,True,True,False
+BL0055-C,Plate_D_E6,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.452,0.728,arabiensis,,True,False,False,False
+BL0058-C,Plate_D_H7,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.045,0.017,gamb_colu,gambiae,False,True,True,False
+BL0059-C,Plate_D_A8,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.459,0.745,arabiensis,,True,False,False,False
+BL0060-C,Plate_D_B8,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.447,0.724,arabiensis,,True,False,False,False
+BL0061-C,Plate_D_D8,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.456,0.744,arabiensis,,True,False,False,False
+BL0062-C,Plate_D_F8,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.452,0.742,arabiensis,,True,False,False,False
+BL0063-C,Plate_D_G8,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.033,0.008,gamb_colu,gambiae,False,True,True,False
+BL0065-C,Plate_D_C9,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.035,0.003,gamb_colu,gambiae,False,True,True,False
+BL0067-C,Plate_B_C2,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.447,0.738,arabiensis,,True,False,False,False
+BL0068-C,Plate_B_D2,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.455,0.739,arabiensis,,True,False,False,False
+BL0069-C,Plate_B_E2,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.452,0.741,arabiensis,,True,False,False,False
+BL0070-C,Plate_B_F2,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.457,0.743,arabiensis,,True,False,False,False
+BL0071-C,Plate_B_G2,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.459,0.74,arabiensis,,True,False,False,False
+BL0072-C,Plate_B_H2,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.453,0.741,arabiensis,,True,False,False,False
+BL0073-C,Plate_B_B4,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.46,0.742,arabiensis,,True,False,False,False
+BL0074-C,Plate_B_C4,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.457,0.736,arabiensis,,True,False,False,False
+BL0075-C,Plate_B_D4,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.449,0.738,arabiensis,,True,False,False,False
+BL0076-C,Plate_B_F4,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.452,0.739,arabiensis,,True,False,False,False
+BL0078-C,Plate_B_G7,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.032,0.004,gamb_colu,gambiae,False,True,True,False
+BL0079-C,Plate_B_B8,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.038,0.019,gamb_colu,gambiae,False,True,True,False
+BL0081-C,Plate_F_B4,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.455,0.744,arabiensis,,True,False,False,False
+BL0082-C,Plate_F_C4,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.453,0.742,arabiensis,,True,False,False,False
+BL0083-C,Plate_F_A5,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.453,0.739,arabiensis,,True,False,False,False
+BL0084-C,Plate_F_B5,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.457,0.74,arabiensis,,True,False,False,False
+BL0085-C,Plate_F_C5,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.457,0.739,arabiensis,,True,False,False,False
+BL0086-C,Plate_F_D5,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.455,0.741,arabiensis,,True,False,False,False
+BL0087-C,Plate_F_E5,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.455,0.743,arabiensis,,True,False,False,False
+BL0088-C,Plate_F_F5,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.455,0.739,arabiensis,,True,False,False,False
+BL0089-C,Plate_F_G5,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.46,0.74,arabiensis,,True,False,False,False
+BL0090-C,Plate_F_H5,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.456,0.74,arabiensis,,True,False,False,False
+BL0091-C,Plate_F_A6,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.455,0.739,arabiensis,,True,False,False,False
+BL0092-C,Plate_F_B6,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.457,0.743,arabiensis,,True,False,False,False
+BL0093-C,Plate_F_D6,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.448,0.741,arabiensis,,True,False,False,False
+BL0094-C,Plate_F_E6,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.452,0.742,arabiensis,,True,False,False,False
+BL0095-C,Plate_F_F6,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.457,0.739,arabiensis,,True,False,False,False
+BL0096-C,Plate_F_G6,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.455,0.742,arabiensis,,True,False,False,False
+BL0097-C,Plate_F_H6,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.458,0.739,arabiensis,,True,False,False,False
+BL0099-C,Plate_F_B7,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.452,0.739,arabiensis,,True,False,False,False
+BL0100-C,Plate_A_A1,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,M,0.035,0.012,gamb_colu,gambiae,False,True,True,False
+BL0101-C,Plate_A_A2,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.036,0.003,gamb_colu,gambiae,False,True,True,False
+BL0102-C,Plate_A_B2,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.028,0.002,gamb_colu,gambiae,False,True,True,False
+BL0103-C,Plate_A_E2,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.024,0.003,gamb_colu,gambiae,False,True,True,False
+BL0105-C,Plate_A_A3,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,M,0.052,0.012,gamb_colu,gambiae,False,True,True,False
+BL0106-C,Plate_A_B3,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,M,0.037,0.013,gamb_colu,gambiae,False,True,True,False
+BL0107-C,Plate_A_C3,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,M,0.043,0.013,gamb_colu,gambiae,False,True,True,False
+BL0108-C,Plate_A_D3,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,M,0.031,0.011,gamb_colu,gambiae,False,True,True,False
+BL0109-C,Plate_A_E3,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,M,0.042,0.01,gamb_colu,gambiae,False,True,True,False
+BL0110-C,Plate_A_F3,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,M,0.082,0.015,gamb_colu,gambiae,False,True,True,False
+BL0111-C,Plate_A_G3,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,M,0.046,0.008,gamb_colu,gambiae,False,True,True,False
+BL0112-C,Plate_A_H3,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,M,0.045,0.01,gamb_colu,gambiae,False,True,True,False
+BL0113-C,Plate_A_G12,AG1000G-TZ,Tanzania,Muleba,2015,4,-1.962,31.651,F,0.454,0.741,arabiensis,,True,False,False,False
+BL0114-C,Plate_B_D11,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.029,0.004,gamb_colu,gambiae,False,True,True,False
+BL0115-C,Plate_B_H11,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.033,0.005,gamb_colu,gambiae,False,True,True,False
+BL0116-C,Plate_B_A12,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.027,0.003,gamb_colu,gambiae,False,True,True,False
+BL0117-C,Plate_B_E12,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.029,0.003,gamb_colu,gambiae,False,True,True,False
+BL0118-C,Plate_B_F12,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.448,0.731,arabiensis,,True,False,False,False
+BL0194-C,Plate_C_A1,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.459,0.751,arabiensis,,True,False,False,False
+BL0195-C,Plate_C_B1,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.46,0.748,arabiensis,,True,False,False,False
+BL0196-C,Plate_C_C1,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.46,0.752,arabiensis,,True,False,False,False
+BL0197-C,Plate_C_D1,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.454,0.746,arabiensis,,True,False,False,False
+BL0198-C,Plate_C_E1,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.46,0.75,arabiensis,,True,False,False,False
+BL0199-C,Plate_C_F1,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.456,0.749,arabiensis,,True,False,False,False
+BL0200-C,Plate_C_G1,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.454,0.75,arabiensis,,True,False,False,False
+BL0201-C,Plate_C_H1,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.459,0.748,arabiensis,,True,False,False,False
+BL0202-C,Plate_C_A2,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.454,0.75,arabiensis,,True,False,False,False
+BL0203-C,Plate_C_C2,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.456,0.747,arabiensis,,True,False,False,False
+BL0204-C,Plate_C_D2,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.461,0.747,arabiensis,,True,False,False,False
+BL0205-C,Plate_A_B1,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.458,0.75,arabiensis,,True,False,False,False
+BL0207-C,Plate_A_D1,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.461,0.751,arabiensis,,True,False,False,False
+BL0208-C,Plate_A_E1,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.461,0.752,arabiensis,,True,False,False,False
+BL0209-C,Plate_A_F1,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.453,0.747,arabiensis,,True,False,False,False
+BL0210-C,Plate_A_G1,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.457,0.75,arabiensis,,True,False,False,False
+BL0211-C,Plate_A_H1,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.456,0.749,arabiensis,,True,False,False,False
+BL0212-C,Plate_A_C2,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.454,0.749,arabiensis,,True,False,False,False
+BL0213-C,Plate_A_D2,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.46,0.748,arabiensis,,True,False,False,False
+BL0214-C,Plate_A_G2,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.456,0.745,arabiensis,,True,False,False,False
+BL0215-C,Plate_A_H2,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.455,0.751,arabiensis,,True,False,False,False
+BL0216-C,Plate_A_A12,AG1000G-TZ,Tanzania,Muleba,2015,4,-1.962,31.651,F,0.459,0.75,arabiensis,,True,False,False,False
+BL0217-C,Plate_A_B12,AG1000G-TZ,Tanzania,Muleba,2015,4,-1.962,31.651,F,0.452,0.749,arabiensis,,True,False,False,False
+BL0218-C,Plate_A_C12,AG1000G-TZ,Tanzania,Muleba,2015,4,-1.962,31.651,F,0.459,0.75,arabiensis,,True,False,False,False
+BL0221-C,Plate_A_F12,AG1000G-TZ,Tanzania,Muleba,2015,4,-1.962,31.651,F,0.455,0.751,arabiensis,,True,False,False,False
+BL0222-C,Plate_A_H12,AG1000G-TZ,Tanzania,Muleba,2015,4,-1.962,31.651,F,0.457,0.747,arabiensis,,True,False,False,False
+BL0223-C,Plate_B_A10,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.463,0.75,arabiensis,,True,False,False,False
+BL0224-C,Plate_B_B10,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.456,0.748,arabiensis,,True,False,False,False
+BL0225-C,Plate_B_C10,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.458,0.749,arabiensis,,True,False,False,False
+BL0226-C,Plate_B_D10,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.453,0.75,arabiensis,,True,False,False,False
+BL0227-C,Plate_B_E10,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.457,0.75,arabiensis,,True,False,False,False
+BL0228-C,Plate_B_F10,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.458,0.749,arabiensis,,True,False,False,False
+BL0229-C,Plate_B_G10,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.454,0.746,arabiensis,,True,False,False,False
+BL0119-C,Plate_E_B11,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.033,0.006,gamb_colu,gambiae,False,True,True,False
+BL0120-C,Plate_E_C11,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.032,0.006,gamb_colu,gambiae,False,True,True,False
+BL0121-C,Plate_E_D11,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.032,0.006,gamb_colu,gambiae,False,True,True,False
+BL0124-C,Plate_E_A12,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.035,0.004,gamb_colu,gambiae,False,True,True,False
+BL0125-C,Plate_E_B12,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.037,0.004,gamb_colu,gambiae,False,True,True,False
+BL0126-C,Plate_E_F12,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.455,0.74,arabiensis,,True,False,False,False
+BL0127-C,Plate_F_A12,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.454,0.739,arabiensis,,True,False,False,False
+BL0128-C,Plate_F_B12,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.023,0.005,gamb_colu,gambiae,False,True,True,False
+BL0129-C,Plate_E_A1,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.454,0.743,arabiensis,,True,False,False,False
+BL0131-C,Plate_E_F3,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.46,0.743,arabiensis,,True,False,False,False
+BL0133-C,Plate_E_E5,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.451,0.744,arabiensis,,True,False,False,False
+BL0135-C,Plate_E_G5,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.451,0.738,arabiensis,,True,False,False,False
+BL0136-C,Plate_E_H5,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.453,0.745,arabiensis,,True,False,False,False
+BL0137-C,Plate_E_A6,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.03,0.005,gamb_colu,gambiae,False,True,True,False
+BL0138-C,Plate_E_B8,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.035,0.005,gamb_colu,gambiae,False,True,True,False
+BL0139-C,Plate_E_F8,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.452,0.744,arabiensis,,True,False,False,False
+BL0140-C,Plate_E_A9,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.455,0.741,arabiensis,,True,False,False,False
+BL0141-C,Plate_E_H9,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.457,0.743,arabiensis,,True,False,False,False
+BL0142-C,Plate_E_B10,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.027,0.003,gamb_colu,gambiae,False,True,True,False
+BL0145-C,Plate_E_H10,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.451,0.74,arabiensis,,True,False,False,False
+BL0146-C,Plate_C_A5,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.454,0.741,arabiensis,,True,False,False,False
+BL0147-C,Plate_C_B5,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.456,0.741,arabiensis,,True,False,False,False
+BL0148-C,Plate_C_C5,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.454,0.732,arabiensis,,True,False,False,False
+BL0149-C,Plate_C_E5,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.451,0.736,arabiensis,,True,False,False,False
+BL0150-C,Plate_C_G5,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.453,0.739,arabiensis,,True,False,False,False
+BL0151-C,Plate_C_H5,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.449,0.741,arabiensis,,True,False,False,False
+BL0152-C,Plate_C_A6,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.453,0.74,arabiensis,,True,False,False,False
+BL0153-C,Plate_C_B6,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.445,0.73,arabiensis,,True,False,False,False
+BL0154-C,Plate_C_C6,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.454,0.74,arabiensis,,True,False,False,False
+BL0155-C,Plate_C_D6,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.457,0.743,arabiensis,,True,False,False,False
+BL0156-C,Plate_C_E6,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.451,0.739,arabiensis,,True,False,False,False
+BL0157-C,Plate_C_F6,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.461,0.75,arabiensis,,True,False,False,False
+BL0158-C,Plate_D_A1,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.457,0.749,arabiensis,,True,False,False,False
+BL0159-C,Plate_D_B1,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.458,0.75,arabiensis,,True,False,False,False
+BL0161-C,Plate_D_F1,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.457,0.748,arabiensis,,True,False,False,False
+BL0163-C,Plate_D_A2,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.457,0.748,arabiensis,,True,False,False,False
+BL0164-C,Plate_D_C2,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.455,0.75,arabiensis,,True,False,False,False
+BL0165-C,Plate_D_E2,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.46,0.75,arabiensis,,True,False,False,False
+BL0166-C,Plate_D_F2,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.457,0.751,arabiensis,,True,False,False,False
+BL0167-C,Plate_D_G2,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.46,0.75,arabiensis,,True,False,False,False
+BL0168-C,Plate_D_H2,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.456,0.751,arabiensis,,True,False,False,False
+BL0169-C,Plate_D_A3,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.456,0.747,arabiensis,,True,False,False,False
+BL0170-C,Plate_B_A1,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.459,0.75,arabiensis,,True,False,False,False
+BL0171-C,Plate_B_B1,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.456,0.75,arabiensis,,True,False,False,False
+BL0172-C,Plate_B_C1,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.459,0.75,arabiensis,,True,False,False,False
+BL0173-C,Plate_B_D1,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.453,0.749,arabiensis,,True,False,False,False
+BL0176-C,Plate_B_G1,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.457,0.749,arabiensis,,True,False,False,False
+BL0177-C,Plate_B_H1,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.454,0.748,arabiensis,,True,False,False,False
+BL0178-C,Plate_B_A3,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.461,0.749,arabiensis,,True,False,False,False
+BL0180-C,Plate_B_C3,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.459,0.747,arabiensis,,True,False,False,False
+BL0182-C,Plate_A_A5,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.452,0.748,arabiensis,,True,False,False,False
+BL0183-C,Plate_A_B5,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.455,0.751,arabiensis,,True,False,False,False
+BL0184-C,Plate_A_E5,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.461,0.75,arabiensis,,True,False,False,False
+BL0185-C,Plate_A_F5,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.456,0.751,arabiensis,,True,False,False,False
+BL0186-C,Plate_A_G5,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.459,0.75,arabiensis,,True,False,False,False
+BL0187-C,Plate_A_H5,AG1000G-TZ,Tanzania,Muleba,2015,3,-1.962,31.651,F,0.463,0.748,arabiensis,,True,False,False,False
+BL0189-C,Plate_A_B6,AG1000G-TZ,Tanzania,Muleba,2015,4,-1.962,31.651,F,0.456,0.744,arabiensis,,True,False,False,False
+BL0190-C,Plate_A_C6,AG1000G-TZ,Tanzania,Muleba,2015,4,-1.962,31.651,F,0.459,0.748,arabiensis,,True,False,False,False
+BL0192-C,Plate_A_F6,AG1000G-TZ,Tanzania,Muleba,2015,4,-1.962,31.651,F,0.456,0.748,arabiensis,,True,False,False,False
+BL0193-C,Plate_A_G6,AG1000G-TZ,Tanzania,Muleba,2015,4,-1.962,31.651,F,0.457,0.747,arabiensis,,True,False,False,False
+BL0230-C,Plate_B_H10,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.461,0.751,arabiensis,,True,False,False,False
+BL0231-C,Plate_B_A11,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.458,0.748,arabiensis,,True,False,False,False
+BL0232-C,Plate_B_B11,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.46,0.75,arabiensis,,True,False,False,False
+BL0233-C,Plate_B_C11,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.456,0.748,arabiensis,,True,False,False,False
+BL0234-C,Plate_E_B1,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.459,0.748,arabiensis,,True,False,False,False
+BL0235-C,Plate_E_C1,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.457,0.751,arabiensis,,True,False,False,False
+BL0236-C,Plate_E_E1,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.458,0.749,arabiensis,,True,False,False,False
+BL0238-C,Plate_E_G1,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.462,0.749,arabiensis,,True,False,False,False
+BL0239-C,Plate_E_H1,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.46,0.75,arabiensis,,True,False,False,False
+BL0240-C,Plate_E_A2,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.456,0.752,arabiensis,,True,False,False,False
+BL0241-C,Plate_E_B2,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.456,0.751,arabiensis,,True,False,False,False
+BL0242-C,Plate_E_C2,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.458,0.75,arabiensis,,True,False,False,False
+BL0243-C,Plate_E_D2,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.453,0.749,arabiensis,,True,False,False,False
+BL0244-C,Plate_E_E2,AG1000G-TZ,Tanzania,Muleba,2015,6,-1.962,31.651,F,0.464,0.748,arabiensis,,True,False,False,False
+BL0246-C,M_330_l,AG1000G-TZ,Tanzania,Moshi,2012,8,-3.482,37.308,F,0.454,0.752,arabiensis,,True,False,False,False
+BL0247-C,M_387_l,AG1000G-TZ,Tanzania,Moshi,2012,8,-3.482,37.308,F,0.454,0.752,arabiensis,,True,False,False,False
+BL0251-C,M_380_l,AG1000G-TZ,Tanzania,Moshi,2012,8,-3.482,37.308,F,0.456,0.749,arabiensis,,True,False,False,False
+BL0252-C,M_332_l,AG1000G-TZ,Tanzania,Moshi,2012,8,-3.482,37.308,F,0.461,0.751,arabiensis,,True,False,False,False
+BL0253-C,M_383_l,AG1000G-TZ,Tanzania,Moshi,2012,8,-3.482,37.308,F,0.458,0.75,arabiensis,,True,False,False,False
+BL0254-C,M_348_l,AG1000G-TZ,Tanzania,Moshi,2012,8,-3.482,37.308,F,0.46,0.751,arabiensis,,True,False,False,False
+BL0255-C,M_376_l,AG1000G-TZ,Tanzania,Moshi,2012,8,-3.482,37.308,F,0.454,0.75,arabiensis,,True,False,False,False
+BL0256-C,M_349_l,AG1000G-TZ,Tanzania,Moshi,2012,8,-3.482,37.308,F,0.459,0.749,arabiensis,,True,False,False,False
+BL0257-C,M_385_l,AG1000G-TZ,Tanzania,Moshi,2012,8,-3.482,37.308,F,0.454,0.751,arabiensis,,True,False,False,False
+BL0258-C,M_394_l,AG1000G-TZ,Tanzania,Moshi,2012,8,-3.482,37.308,F,0.457,0.751,arabiensis,,True,False,False,False
+BL0259-C,M_360_l,AG1000G-TZ,Tanzania,Moshi,2012,8,-3.482,37.308,F,0.453,0.75,arabiensis,,True,False,False,False
+BL0260-C,M_340_l,AG1000G-TZ,Tanzania,Moshi,2012,8,-3.482,37.308,F,0.456,0.751,arabiensis,,True,False,False,False
+BL0261-C,M_266_l,AG1000G-TZ,Tanzania,Moshi,2012,8,-3.482,37.308,F,0.458,0.751,arabiensis,,True,False,False,False
+BL0263-C,M_307_l,AG1000G-TZ,Tanzania,Moshi,2012,8,-3.482,37.308,F,0.458,0.75,arabiensis,,True,False,False,False
+BL0264-C,M_260_l,AG1000G-TZ,Tanzania,Moshi,2012,8,-3.482,37.308,F,0.454,0.749,arabiensis,,True,False,False,False
+BL0266-C,M_276_l,AG1000G-TZ,Tanzania,Moshi,2012,8,-3.482,37.308,F,0.46,0.752,arabiensis,,True,False,False,False
+BL0267-C,M_261_l,AG1000G-TZ,Tanzania,Moshi,2012,8,-3.482,37.308,F,0.458,0.748,arabiensis,,True,False,False,False
+BL0269-C,M_286_l,AG1000G-TZ,Tanzania,Moshi,2012,8,-3.482,37.308,F,0.457,0.751,arabiensis,,True,False,False,False
+BL0271-C,M_647_d,AG1000G-TZ,Tanzania,Moshi,2012,8,-3.482,37.308,F,0.463,0.75,arabiensis,,True,False,False,False
+BL0272-C,M_653_d,AG1000G-TZ,Tanzania,Moshi,2012,8,-3.482,37.308,F,0.463,0.751,arabiensis,,True,False,False,False
+BL0273-C,M_644_d,AG1000G-TZ,Tanzania,Moshi,2012,8,-3.482,37.308,F,0.456,0.75,arabiensis,,True,False,False,False
+BL0275-C,M_636_d,AG1000G-TZ,Tanzania,Moshi,2012,8,-3.482,37.308,F,0.457,0.75,arabiensis,,True,False,False,False
+BL0276-C,M_638_d,AG1000G-TZ,Tanzania,Moshi,2012,8,-3.482,37.308,F,0.454,0.751,arabiensis,,True,False,False,False
+BL0277-C,M_650_d,AG1000G-TZ,Tanzania,Moshi,2012,8,-3.482,37.308,F,0.461,0.751,arabiensis,,True,False,False,False
+BL0278-C,M_709_d,AG1000G-TZ,Tanzania,Moshi,2012,8,-3.482,37.308,F,0.453,0.752,arabiensis,,True,False,False,False
+BL0280-C,M_717_d,AG1000G-TZ,Tanzania,Moshi,2012,8,-3.482,37.308,F,0.456,0.748,arabiensis,,True,False,False,False
+BL0281-C,M_704_d,AG1000G-TZ,Tanzania,Moshi,2012,8,-3.482,37.308,F,0.457,0.752,arabiensis,,True,False,False,False
+BL0282-C,M_696_d,AG1000G-TZ,Tanzania,Moshi,2012,8,-3.482,37.308,F,0.458,0.75,arabiensis,,True,False,False,False
+BL0283-C,M_691_d,AG1000G-TZ,Tanzania,Moshi,2012,8,-3.482,37.308,F,0.455,0.749,arabiensis,,True,False,False,False
+BL0284-C,M_726_d,AG1000G-TZ,Tanzania,Moshi,2012,8,-3.482,37.308,F,0.46,0.749,arabiensis,,True,False,False,False
+BL0285-C,M_718_d,AG1000G-TZ,Tanzania,Moshi,2012,8,-3.482,37.308,F,0.46,0.75,arabiensis,,True,False,False,False
+BL0286-C,M_720_d,AG1000G-TZ,Tanzania,Moshi,2012,8,-3.482,37.308,F,0.459,0.75,arabiensis,,True,False,False,False
+BL0287-C,M_681_d,AG1000G-TZ,Tanzania,Moshi,2012,8,-3.482,37.308,F,0.456,0.751,arabiensis,,True,False,False,False
+BL0288-C,M_721_d,AG1000G-TZ,Tanzania,Moshi,2012,8,-3.482,37.308,F,0.465,0.751,arabiensis,,True,False,False,False
+BL0290-C,M_711_d,AG1000G-TZ,Tanzania,Moshi,2012,8,-3.482,37.308,F,0.459,0.751,arabiensis,,True,False,False,False
+BL0291-C,M_712_d,AG1000G-TZ,Tanzania,Moshi,2012,8,-3.482,37.308,F,0.457,0.75,arabiensis,,True,False,False,False
+BL0292-C,M_715_d,AG1000G-TZ,Tanzania,Moshi,2012,8,-3.482,37.308,F,0.462,0.751,arabiensis,,True,False,False,False
+BL0293-C,M_757_d,AG1000G-TZ,Tanzania,Moshi,2012,8,-3.482,37.308,F,0.453,0.75,arabiensis,,True,False,False,False
+BL0294-C,M_748_d,AG1000G-TZ,Tanzania,Moshi,2012,8,-3.482,37.308,F,0.463,0.751,arabiensis,,True,False,False,False
+BL0296-C,T_1s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.455,0.749,arabiensis,,True,False,False,False
+BL0297-C,T_2s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.456,0.751,arabiensis,,True,False,False,False
+BL0298-C,T_3s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.457,0.748,arabiensis,,True,False,False,False
+BL0299-C,T_4s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.458,0.749,arabiensis,,True,False,False,False
+BL0300-C,T_5s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.462,0.748,arabiensis,,True,False,False,False
+BL0301-C,T_6s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.459,0.75,arabiensis,,True,False,False,False
+BL0302-C,T_7s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.46,0.751,arabiensis,,True,False,False,False
+BL0303-C,T_8s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.452,0.75,arabiensis,,True,False,False,False
+BL0304-C,T_9s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.458,0.749,arabiensis,,True,False,False,False
+BL0305-C,T_10s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.458,0.75,arabiensis,,True,False,False,False
+BL0306-C,T_11s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.457,0.749,arabiensis,,True,False,False,False
+BL0307-C,T_12s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.46,0.75,arabiensis,,True,False,False,False
+BL0308-C,T_13s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.457,0.75,arabiensis,,True,False,False,False
+BL0309-C,T_14s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.454,0.748,arabiensis,,True,False,False,False
+BL0310-C,T_15s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.457,0.747,arabiensis,,True,False,False,False
+BL0311-C,T_16s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.459,0.75,arabiensis,,True,False,False,False
+BL0312-C,T_17s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.454,0.751,arabiensis,,True,False,False,False
+BL0313-C,T_18s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.451,0.748,arabiensis,,True,False,False,False
+BL0314-C,T_19s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.454,0.751,arabiensis,,True,False,False,False
+BL0315-C,T_20s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.458,0.752,arabiensis,,True,False,False,False
+BL0316-C,T_21s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.458,0.749,arabiensis,,True,False,False,False
+BL0317-C,T_22s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.459,0.748,arabiensis,,True,False,False,False
+BL0318-C,T_23s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.459,0.75,arabiensis,,True,False,False,False
+BL0319-C,T_24s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.454,0.75,arabiensis,,True,False,False,False
+BL0320-C,T_25s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.456,0.749,arabiensis,,True,False,False,False
+BL0321-C,T_26s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.459,0.75,arabiensis,,True,False,False,False
+BL0322-C,T_27s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.46,0.75,arabiensis,,True,False,False,False
+BL0323-C,T_28s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.451,0.749,arabiensis,,True,False,False,False
+BL0324-C,T_29s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.46,0.75,arabiensis,,True,False,False,False
+BL0325-C,T_30s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.46,0.748,arabiensis,,True,False,False,False
+BL0326-C,T_31s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.454,0.748,arabiensis,,True,False,False,False
+BL0327-C,T_32s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.46,0.75,arabiensis,,True,False,False,False
+BL0328-C,T_33s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.457,0.75,arabiensis,,True,False,False,False
+BL0332-C,T_37s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.453,0.738,arabiensis,,True,False,False,False
+BL0333-C,T_38s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.458,0.738,arabiensis,,True,False,False,False
+BL0334-C,T_39s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.455,0.736,arabiensis,,True,False,False,False
+BL0335-C,T_40s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.453,0.737,arabiensis,,True,False,False,False
+BL0336-C,T_41s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.451,0.74,arabiensis,,True,False,False,False
+BL0337-C,T_42s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.454,0.736,arabiensis,,True,False,False,False
+BL0338-C,T_43s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.45,0.741,arabiensis,,True,False,False,False
+BL0339-C,T_44s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.451,0.736,arabiensis,,True,False,False,False
+BL0340-C,T_45s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.455,0.739,arabiensis,,True,False,False,False
+BL0341-C,T_46s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.457,0.736,arabiensis,,True,False,False,False
+BL0342-C,T_47s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.45,0.74,arabiensis,,True,False,False,False
+BL0343-C,T_48s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.455,0.737,arabiensis,,True,False,False,False
+BL0344-C,T_49s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.451,0.738,arabiensis,,True,False,False,False
+BL0345-C,T_50s,AG1000G-TZ,Tanzania,Tarime,2012,8,-1.431,34.199,F,0.456,0.738,arabiensis,,True,False,False,False
+BL0346-C,M_1,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.038,0.002,gamb_colu,gambiae,False,True,True,False
+BL0347-C,M_2,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.052,0.003,gamb_colu,gambiae,False,True,True,False
+BL0348-C,M_3,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.049,0.002,gamb_colu,gambiae,False,True,True,False
+BL0350-C,M_5,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.029,0.005,gamb_colu,gambiae,False,True,True,False
+BL0351-C,M_6,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+BL0352-C,M_7,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.156,0.005,gamb_colu,intermediate,False,True,False,False
+BL0353-C,M_8,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.037,0.003,gamb_colu,gambiae,False,True,True,False
+BL0354-C,M_9,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.039,0.005,gamb_colu,gambiae,False,True,True,False
+BL0356-C,M_11,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.04,0.005,gamb_colu,gambiae,False,True,True,False
+BL0357-C,M_12,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.073,0.01,gamb_colu,gambiae,False,True,True,False
+BL0358-C,M_13,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.136,0.023,gamb_colu,intermediate,False,True,False,False
+BL0359-C,M_14,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.042,0.003,gamb_colu,gambiae,False,True,True,False
+BL0360-C,M_15,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.15,0.006,gamb_colu,intermediate,False,True,False,False
+BL0361-C,M_16,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.043,0.005,gamb_colu,gambiae,False,True,True,False
+BL0362-C,M_17,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.044,0.004,gamb_colu,gambiae,False,True,True,False
+BL0363-C,M_18,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.052,0.005,gamb_colu,gambiae,False,True,True,False
+BL0365-C,M_20,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.167,0.01,gamb_colu,intermediate,False,True,False,False
+BL0366-C,M_21,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.103,0.018,gamb_colu,gambiae,False,True,True,False
+BL0367-C,M_22,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.153,0.006,gamb_colu,intermediate,False,True,False,False
+BL0368-C,M_23,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.035,0.002,gamb_colu,gambiae,False,True,True,False
+BL0370-C,M_25,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.096,0.005,gamb_colu,gambiae,False,True,True,False
+BL0371-C,M_26,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.044,0.006,gamb_colu,gambiae,False,True,True,False
+BL0372-C,M_27,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.035,0.005,gamb_colu,gambiae,False,True,True,False
+BL0373-C,M_28,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.431,0.686,arabiensis,,True,False,False,False
+BL0375-C,M_30,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.033,0.003,gamb_colu,gambiae,False,True,True,False
+BL0376-C,M_31,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.038,0.004,gamb_colu,gambiae,False,True,True,False
+BL0377-C,M_32,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.037,0.002,gamb_colu,gambiae,False,True,True,False
+BL0378-C,M_33,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.034,0.003,gamb_colu,gambiae,False,True,True,False
+BL0379-C,M_34,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.036,0.004,gamb_colu,gambiae,False,True,True,False
+BL0380-C,M_35,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.045,0.002,gamb_colu,gambiae,False,True,True,False
+BL0381-C,M_36,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.051,0.002,gamb_colu,gambiae,False,True,True,False
+BL0382-C,M_37,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.037,0.002,gamb_colu,gambiae,False,True,True,False
+BL0383-C,M_38,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.048,0.004,gamb_colu,gambiae,False,True,True,False
+BL0384-C,M_39,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.09,0.005,gamb_colu,gambiae,False,True,True,False
+BL0385-C,M_40,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.034,0.002,gamb_colu,gambiae,False,True,True,False
+BL0386-C,M_41,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.031,0.004,gamb_colu,gambiae,False,True,True,False
+BL0387-C,M_42,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.037,0.003,gamb_colu,gambiae,False,True,True,False
+BL0388-C,M_43,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.041,0.004,gamb_colu,gambiae,False,True,True,False
+BL0389-C,M_44,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.048,0.006,gamb_colu,gambiae,False,True,True,False
+BL0391-C,M_46,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.048,0.002,gamb_colu,gambiae,False,True,True,False
+BL0392-C,M_47,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.036,0.002,gamb_colu,gambiae,False,True,True,False
+BL0393-C,M_48,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.041,0.006,gamb_colu,gambiae,False,True,True,False
+BL0394-C,M_49,AG1000G-TZ,Tanzania,Muheza,2013,1,-4.94,38.948,F,0.128,0.004,gamb_colu,intermediate,False,True,False,False
+BL0250-CW,M_381_l,AG1000G-TZ,Tanzania,Moshi,2012,8,-3.482,37.308,M,0.459,0.744,arabiensis,,True,False,False,False
+AC0007-C,1_A2,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.458,0.741,arabiensis,,True,False,False,False
+AC0008-C,1_A6,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.456,0.74,arabiensis,,True,False,False,False
+AC0009-Cx,1_A7,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.458,0.746,arabiensis,,True,False,False,False
+AC0010-C,1_A9,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.452,0.743,arabiensis,,True,False,False,False
+AC0011-C,1_B5,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.455,0.745,arabiensis,,True,False,False,False
+AC0012-Cx,1_B6,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.456,0.745,arabiensis,,True,False,False,False
+AC0013-Cx,1_B7,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.458,0.742,arabiensis,,True,False,False,False
+AC0014-C,1_B9,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.452,0.742,arabiensis,,True,False,False,False
+AC0015-C,1_B10,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.456,0.741,arabiensis,,True,False,False,False
+AC0016-C,1_C2,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.461,0.733,arabiensis,,True,False,False,False
+AC0017-C,1_C5,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.46,0.745,arabiensis,,True,False,False,False
+AC0018-Cx,1_C6,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.459,0.747,arabiensis,,True,False,False,False
+AC0019-C,1_C8,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.456,0.745,arabiensis,,True,False,False,False
+AC0021-C,1_C10,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.456,0.747,arabiensis,,True,False,False,False
+AC0022-C,1_D1,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.454,0.74,arabiensis,,True,False,False,False
+AC0023-C,1_D8,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.453,0.745,arabiensis,,True,False,False,False
+AC0024-Cx,1_D10,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.458,0.743,arabiensis,,True,False,False,False
+AC0025-C,1_D11,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.457,0.729,arabiensis,,True,False,False,False
+AC0026-C,1_E2,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.455,0.743,arabiensis,,True,False,False,False
+AC0027-C,1_E5,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.451,0.743,arabiensis,,True,False,False,False
+AC0028-C,1_E6,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.457,0.741,arabiensis,,True,False,False,False
+AC0029-C,1_E8,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.451,0.719,arabiensis,,True,False,False,False
+AC0030-C,1_E9,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.46,0.746,arabiensis,,True,False,False,False
+AC0031-Cx,1_F5,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.449,0.745,arabiensis,,True,False,False,False
+AC0032-C,1_F8,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.454,0.738,arabiensis,,True,False,False,False
+AC0033-Cx,1_F10,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.455,0.738,arabiensis,,True,False,False,False
+AC0034-C,1_G2,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.464,0.747,arabiensis,,True,False,False,False
+AC0035-C,1_G5,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.459,0.745,arabiensis,,True,False,False,False
+AC0036-C,1_G8,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.457,0.743,arabiensis,,True,False,False,False
+AC0037-C,1_G9,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.456,0.742,arabiensis,,True,False,False,False
+AC0038-Cx,1_H4,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.455,0.746,arabiensis,,True,False,False,False
+AC0039-C,1_H5,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.46,0.746,arabiensis,,True,False,False,False
+AC0040-C,1_H6,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.461,0.744,arabiensis,,True,False,False,False
+AC0041-Cx,1_H7,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.462,0.745,arabiensis,,True,False,False,False
+AC0042-C,1_H9,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.458,0.742,arabiensis,,True,False,False,False
+AC0043-C,1_H12,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.46,0.745,arabiensis,,True,False,False,False
+AC0044-Cx,2_A3,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.456,0.743,arabiensis,,True,False,False,False
+AC0045-C,2_A5,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.452,0.744,arabiensis,,True,False,False,False
+AC0046-C,2_A7,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.455,0.744,arabiensis,,True,False,False,False
+AC0047-C,2_A8,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.459,0.746,arabiensis,,True,False,False,False
+AC0048-Cx,2_A10,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.458,0.74,arabiensis,,True,False,False,False
+AC0049-C,2_A11,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.457,0.748,arabiensis,,True,False,False,False
+AC0050-Cx,2_A12,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.455,0.744,arabiensis,,True,False,False,False
+AC0051-C,2_B3,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.41,0.654,arabiensis,,True,False,False,False
+AC0052-Cx,2_B5,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.455,0.741,arabiensis,,True,False,False,False
+AC0053-C,2_B9,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.454,0.741,arabiensis,,True,False,False,False
+AC0054-C,2_C1,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.454,0.736,arabiensis,,True,False,False,False
+AC0055-C,2_C5,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.459,0.745,arabiensis,,True,False,False,False
+AC0056-C,2_C9,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.46,0.746,arabiensis,,True,False,False,False
+AC0057-C,2_C11,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.462,0.741,arabiensis,,True,False,False,False
+AC0058-C,2_D1,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.458,0.74,arabiensis,,True,False,False,False
+AC0059-C,2_D2,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.453,0.745,arabiensis,,True,False,False,False
+AC0060-C,2_D3,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.464,0.745,arabiensis,,True,False,False,False
+AC0061-C,2_D6,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.454,0.741,arabiensis,,True,False,False,False
+AC0062-C,2_D7,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.456,0.745,arabiensis,,True,False,False,False
+AC0063-C,2_D10,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.461,0.744,arabiensis,,True,False,False,False
+AC0064-C,2_D12,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.457,0.744,arabiensis,,True,False,False,False
+AC0065-C,2_E4,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.456,0.731,arabiensis,,True,False,False,False
+AC0066-C,2_E8,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.462,0.748,arabiensis,,True,False,False,False
+AC0067-Cx,2_E12,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.462,0.745,arabiensis,,True,False,False,False
+AC0068-C,2_F6,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.461,0.743,arabiensis,,True,False,False,False
+AC0069-C,2_F8,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.461,0.744,arabiensis,,True,False,False,False
+AC0070-C,2_F10,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.441,0.699,arabiensis,,True,False,False,False
+AC0071-C,2_F12,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.457,0.745,arabiensis,,True,False,False,False
+AC0072-C,2_G1,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.464,0.747,arabiensis,,True,False,False,False
+AC0073-C,2_G2,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.459,0.746,arabiensis,,True,False,False,False
+AC0074-C,2_G3,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.462,0.743,arabiensis,,True,False,False,False
+AC0075-C,2_G8,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.455,0.747,arabiensis,,True,False,False,False
+AC0076-C,2_G10,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.459,0.746,arabiensis,,True,False,False,False
+AC0077-C,2_H1,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.449,0.745,arabiensis,,True,False,False,False
+AC0078-C,2_H2,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.454,0.745,arabiensis,,True,False,False,False
+AC0079-C,2_H5,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.455,0.745,arabiensis,,True,False,False,False
+AC0080-Cx,3_A3,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.456,0.748,arabiensis,,True,False,False,False
+AC0081-C,3_B1,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.457,0.729,arabiensis,,True,False,False,False
+AC0082-C,3_B2,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.432,0.685,arabiensis,,True,False,False,False
+AC0083-C,3_C1,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.458,0.746,arabiensis,,True,False,False,False
+AC0084-C,3_C2,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.457,0.746,arabiensis,,True,False,False,False
+AC0085-C,3_E2,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.454,0.733,arabiensis,,True,False,False,False
+AC0086-C,3_F1,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.451,0.742,arabiensis,,True,False,False,False
+AC0087-Cx,3_F2,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.454,0.741,arabiensis,,True,False,False,False
+AC0088-C,3_G1,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.46,0.747,arabiensis,,True,False,False,False
+AC0089-Cx,1_A1,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AC0090-C,1_A4,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.025,0.003,gamb_colu,gambiae,False,True,True,False
+AC0091-Cx,1_A5,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.032,0.002,gamb_colu,gambiae,False,True,True,False
+AC0092-C,1_A8,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.032,0.003,gamb_colu,gambiae,False,True,True,False
+AC0093-C,1_A10,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.033,0.002,gamb_colu,gambiae,False,True,True,False
+AC0094-C,1_A12,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.038,0.002,gamb_colu,gambiae,False,True,True,False
+AC0095-C,1_B2,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.033,0.002,gamb_colu,gambiae,False,True,True,False
+AC0096-Cx,1_B3,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AC0097-C,1_B4,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.034,0.003,gamb_colu,gambiae,False,True,True,False
+AC0098-C,1_B8,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.033,0.003,gamb_colu,gambiae,False,True,True,False
+AC0099-C,1_B11,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AC0100-C,1_B12,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.028,0.002,gamb_colu,gambiae,False,True,True,False
+AC0101-C,1_C3,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.023,0.003,gamb_colu,gambiae,False,True,True,False
+AC0102-Cx,1_C4,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.018,0.003,gamb_colu,gambiae,False,True,True,False
+AC0103-Cx,1_C7,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.031,0.002,gamb_colu,gambiae,False,True,True,False
+AC0104-Cx,1_C11,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AC0105-C,1_C12,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.02,0.002,gamb_colu,gambiae,False,True,True,False
+AC0106-C,1_D2,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AC0107-C,1_D3,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AC0108-C,1_D4,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AC0109-C,1_D5,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.039,0.002,gamb_colu,gambiae,False,True,True,False
+AC0110-Cx,1_D6,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AC0111-Cx,1_D7,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.046,0.003,gamb_colu,gambiae,False,True,True,False
+AC0112-C,1_D9,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.026,0.003,gamb_colu,gambiae,False,True,True,False
+AC0113-Cx,1_D12,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AC0114-C,1_E1,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.034,0.003,gamb_colu,gambiae,False,True,True,False
+AC0115-C,1_E3,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.02,0.003,gamb_colu,gambiae,False,True,True,False
+AC0116-C,1_E4,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AC0117-Cx,1_E7,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.033,0.003,gamb_colu,gambiae,False,True,True,False
+AC0118-C,1_E10,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.025,0.003,gamb_colu,gambiae,False,True,True,False
+AC0119-C,1_E11,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AC0120-C,1_E12,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.03,0.003,gamb_colu,gambiae,False,True,True,False
+AC0121-C,1_F1,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AC0122-C,1_F2,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.024,0.003,gamb_colu,gambiae,False,True,True,False
+AC0123-C,1_F3,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.026,0.003,gamb_colu,gambiae,False,True,True,False
+AC0124-C,1_F4,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AC0125-C,1_F6,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AC0126-Cx,1_F7,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.026,0.003,gamb_colu,gambiae,False,True,True,False
+AC0127-C,1_F9,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.028,0.003,gamb_colu,gambiae,False,True,True,False
+AC0128-Cx,1_F11,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+AC0129-C,1_F12,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.025,0.003,gamb_colu,gambiae,False,True,True,False
+AC0130-C,1_G1,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.032,0.003,gamb_colu,gambiae,False,True,True,False
+AC0131-C,1_G3,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.016,0.002,gamb_colu,gambiae,False,True,True,False
+AC0132-C,1_G4,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.031,0.003,gamb_colu,gambiae,False,True,True,False
+AC0133-C,1_G7,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+AC0134-Cx,1_G10,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.027,0.003,gamb_colu,gambiae,False,True,True,False
+AC0135-C,1_G11,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AC0136-C,1_G12,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.031,0.003,gamb_colu,gambiae,False,True,True,False
+AC0137-C,1_H1,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.037,0.003,gamb_colu,gambiae,False,True,True,False
+AC0138-Cx,1_H2,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AC0139-C,1_H3,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.034,0.003,gamb_colu,gambiae,False,True,True,False
+AC0140-C,1_H8,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AC0141-C,1_H11,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.031,0.002,gamb_colu,gambiae,False,True,True,False
+AC0142-C,2_A1,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AC0143-C,2_A2,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.024,0.003,gamb_colu,gambiae,False,True,True,False
+AC0144-Cx,2_A6,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AC0145-Cx,2_A9,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AC0146-C,2_B1,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AC0147-Cx,2_B4,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.032,0.002,gamb_colu,gambiae,False,True,True,False
+AC0148-C,2_B6,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.038,0.003,gamb_colu,gambiae,False,True,True,False
+AC0149-Cx,2_B7,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AC0150-C,2_B8,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AC0151-C,2_B10,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AC0152-C,2_B11,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AC0153-C,2_B12,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.031,0.002,gamb_colu,gambiae,False,True,True,False
+AC0154-C,2_C2,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+AC0155-C,2_C3,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.037,0.002,gamb_colu,gambiae,False,True,True,False
+AC0156-C,2_C4,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AC0157-C,2_C6,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.042,0.003,gamb_colu,gambiae,False,True,True,False
+AC0158-C,2_C7,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.03,0.002,gamb_colu,gambiae,False,True,True,False
+AC0159-C,2_C8,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.021,0.003,gamb_colu,gambiae,False,True,True,False
+AC0160-C,2_C12,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.016,0.002,gamb_colu,gambiae,False,True,True,False
+AC0161-C,2_D4,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.03,0.002,gamb_colu,gambiae,False,True,True,False
+AC0162-Cx,2_D5,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AC0163-C,2_D8,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.033,0.002,gamb_colu,gambiae,False,True,True,False
+AC0164-C,2_D9,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.034,0.002,gamb_colu,gambiae,False,True,True,False
+AC0166-C,2_E1,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.018,0.003,gamb_colu,gambiae,False,True,True,False
+AC0167-C,2_E2,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.036,0.003,gamb_colu,gambiae,False,True,True,False
+AC0168-Cx,2_E3,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.027,0.003,gamb_colu,gambiae,False,True,True,False
+AC0169-C,2_E5,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AC0170-C,2_E6,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.034,0.003,gamb_colu,gambiae,False,True,True,False
+AC0171-C,2_E9,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+AC0172-C,2_E10,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.015,0.002,gamb_colu,gambiae,False,True,True,False
+AC0173-C,2_E11,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AC0174-Cx,2_F1,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.031,0.003,gamb_colu,gambiae,False,True,True,False
+AC0176-Cx,2_F3,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.02,0.003,gamb_colu,gambiae,False,True,True,False
+AC0177-C,2_F4,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AC0178-C,2_F5,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.03,0.002,gamb_colu,gambiae,False,True,True,False
+AC0179-C,2_F9,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.039,0.002,gamb_colu,gambiae,False,True,True,False
+AC0180-C,2_F11,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.02,0.002,gamb_colu,gambiae,False,True,True,False
+AC0181-C,2_G4,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.034,0.002,gamb_colu,gambiae,False,True,True,False
+AC0182-C,2_G5,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.026,0.003,gamb_colu,gambiae,False,True,True,False
+AC0183-C,2_G6,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AC0184-C,2_G7,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.033,0.003,gamb_colu,gambiae,False,True,True,False
+AC0185-C,2_G9,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.03,0.003,gamb_colu,gambiae,False,True,True,False
+AC0186-C,2_G11,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AC0187-C,2_G12,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+AC0188-C,2_H3,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AC0189-C,2_H4,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.027,0.003,gamb_colu,gambiae,False,True,True,False
+AC0190-C,2_H6,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.036,0.003,gamb_colu,gambiae,False,True,True,False
+AC0191-C,2_H7,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.036,0.002,gamb_colu,gambiae,False,True,True,False
+AC0192-C,2_H8,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AC0193-C,2_H9,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.025,0.003,gamb_colu,gambiae,False,True,True,False
+AC0194-C,2_H10,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.033,0.003,gamb_colu,gambiae,False,True,True,False
+AC0195-C,2_H11,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.035,0.002,gamb_colu,gambiae,False,True,True,False
+AC0196-C,2_H12,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.03,0.002,gamb_colu,gambiae,False,True,True,False
+AC0197-Cx,3_A1,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AC0198-C,3_A2,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.215,0.323,intermediate,,False,False,False,False
+AC0199-C,3_D1,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AC0200-C,3_D2,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.034,0.002,gamb_colu,gambiae,False,True,True,False
+AC0201-Cx,3_E1,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.022,0.003,gamb_colu,gambiae,False,True,True,False
+AC0202-Cx,3_G2,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AC0203-C,3_H2,AG1000G-UG,Uganda,Nagongera,2012,10,0.77,34.026,F,0.031,0.002,gamb_colu,gambiae,False,True,True,False
+AC0204-C,K1,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.035,0.003,gamb_colu,gambiae,False,True,True,False
+AC0205-C,K2,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.449,0.72,arabiensis,,True,False,False,False
+AC0206-C,K3,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+AC0207-C,K4,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.028,0.003,gamb_colu,gambiae,False,True,True,False
+AC0208-C,K5,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.026,0.003,gamb_colu,gambiae,False,True,True,False
+AC0209-C,K6,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.025,0.003,gamb_colu,gambiae,False,True,True,False
+AC0210-C,K7,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AC0211-C,K8,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.026,0.003,gamb_colu,gambiae,False,True,True,False
+AC0212-C,K9,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AC0213-C,K10,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.025,0.003,gamb_colu,gambiae,False,True,True,False
+AC0214-C,K11,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AC0215-C,K12,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.035,0.003,gamb_colu,gambiae,False,True,True,False
+AC0216-C,K13,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.033,0.002,gamb_colu,gambiae,False,True,True,False
+AC0217-C,K14,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.03,0.002,gamb_colu,gambiae,False,True,True,False
+AC0218-C,K15,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AC0219-C,K16,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.044,0.002,gamb_colu,gambiae,False,True,True,False
+AC0220-C,K17,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.029,0.003,gamb_colu,gambiae,False,True,True,False
+AC0221-C,K18,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.025,0.003,gamb_colu,gambiae,False,True,True,False
+AC0222-C,K19,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.033,0.003,gamb_colu,gambiae,False,True,True,False
+AC0223-C,K20,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.04,0.003,gamb_colu,gambiae,False,True,True,False
+AC0224-C,K21,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.013,0.002,gamb_colu,gambiae,False,True,True,False
+AC0225-C,K22,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.024,0.003,gamb_colu,gambiae,False,True,True,False
+AC0226-C,K23,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.023,0.003,gamb_colu,gambiae,False,True,True,False
+AC0227-C,K24,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.033,0.002,gamb_colu,gambiae,False,True,True,False
+AC0228-C,K25,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.017,0.002,gamb_colu,gambiae,False,True,True,False
+AC0229-C,K26,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.028,0.002,gamb_colu,gambiae,False,True,True,False
+AC0230-C,K27,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.03,0.002,gamb_colu,gambiae,False,True,True,False
+AC0231-C,K28,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.04,0.003,gamb_colu,gambiae,False,True,True,False
+AC0232-C,K29,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AC0233-C,K30,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.034,0.002,gamb_colu,gambiae,False,True,True,False
+AC0234-C,K31,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.021,0.002,gamb_colu,gambiae,False,True,True,False
+AC0235-C,K32,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.025,0.002,gamb_colu,gambiae,False,True,True,False
+AC0236-C,K33,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.019,0.002,gamb_colu,gambiae,False,True,True,False
+AC0237-C,K34,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.027,0.003,gamb_colu,gambiae,False,True,True,False
+AC0238-C,K35,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.033,0.002,gamb_colu,gambiae,False,True,True,False
+AC0239-C,K36,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.034,0.002,gamb_colu,gambiae,False,True,True,False
+AC0240-C,K37,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.034,0.002,gamb_colu,gambiae,False,True,True,False
+AC0241-C,K38,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AC0242-C,K39,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.033,0.002,gamb_colu,gambiae,False,True,True,False
+AC0243-C,K40,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AC0244-C,K41,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AC0245-C,K42,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.036,0.003,gamb_colu,gambiae,False,True,True,False
+AC0246-C,K43,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.029,0.003,gamb_colu,gambiae,False,True,True,False
+AC0247-C,K44,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.032,0.003,gamb_colu,gambiae,False,True,True,False
+AC0248-C,K45,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.027,0.003,gamb_colu,gambiae,False,True,True,False
+AC0249-C,K46,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AC0250-C,K47,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AC0251-C,K48,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.031,0.002,gamb_colu,gambiae,False,True,True,False
+AC0252-C,K49,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.023,0.002,gamb_colu,gambiae,False,True,True,False
+AC0253-C,K50,AG1000G-UG,Uganda,Kihihi,2012,10,-0.751,29.701,F,0.025,0.003,gamb_colu,gambiae,False,True,True,False
+AC0254-C,K51,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.022,0.002,gamb_colu,gambiae,False,True,True,False
+AC0255-C,K52,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.033,0.002,gamb_colu,gambiae,False,True,True,False
+AC0256-C,K53,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.028,0.002,gamb_colu,gambiae,False,True,True,False
+AC0257-C,K54,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.025,0.003,gamb_colu,gambiae,False,True,True,False
+AC0258-C,K55,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.032,0.003,gamb_colu,gambiae,False,True,True,False
+AC0259-C,K56,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.019,0.002,gamb_colu,gambiae,False,True,True,False
+AC0260-C,K57,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.032,0.003,gamb_colu,gambiae,False,True,True,False
+AC0261-C,K58,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.032,0.002,gamb_colu,gambiae,False,True,True,False
+AC0262-C,K59,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.036,0.002,gamb_colu,gambiae,False,True,True,False
+AC0263-C,K60,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AC0264-C,K61,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.03,0.003,gamb_colu,gambiae,False,True,True,False
+AC0265-C,K62,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.025,0.003,gamb_colu,gambiae,False,True,True,False
+AC0266-C,K63,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.028,0.002,gamb_colu,gambiae,False,True,True,False
+AC0267-C,K64,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.032,0.002,gamb_colu,gambiae,False,True,True,False
+AC0268-C,K65,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.03,0.002,gamb_colu,gambiae,False,True,True,False
+AC0269-C,K66,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.024,0.002,gamb_colu,gambiae,False,True,True,False
+AC0270-C,K67,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.021,0.003,gamb_colu,gambiae,False,True,True,False
+AC0271-C,K68,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.027,0.003,gamb_colu,gambiae,False,True,True,False
+AC0272-C,K69,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.042,0.003,gamb_colu,gambiae,False,True,True,False
+AC0273-C,K70,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.023,0.003,gamb_colu,gambiae,False,True,True,False
+AC0274-C,K71,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.026,0.003,gamb_colu,gambiae,False,True,True,False
+AC0275-C,K72,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.021,0.003,gamb_colu,gambiae,False,True,True,False
+AC0276-C,K73,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.024,0.003,gamb_colu,gambiae,False,True,True,False
+AC0277-C,K74,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.033,0.003,gamb_colu,gambiae,False,True,True,False
+AC0278-C,K75,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.027,0.002,gamb_colu,gambiae,False,True,True,False
+AC0279-C,K76,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.024,0.003,gamb_colu,gambiae,False,True,True,False
+AC0280-C,K77,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.024,0.003,gamb_colu,gambiae,False,True,True,False
+AC0281-C,K78,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.032,0.002,gamb_colu,gambiae,False,True,True,False
+AC0282-C,K79,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.02,0.003,gamb_colu,gambiae,False,True,True,False
+AC0283-C,K80,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.028,0.003,gamb_colu,gambiae,False,True,True,False
+AC0284-C,K81,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.033,0.003,gamb_colu,gambiae,False,True,True,False
+AC0285-C,K82,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.033,0.003,gamb_colu,gambiae,False,True,True,False
+AC0286-C,K83,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.03,0.002,gamb_colu,gambiae,False,True,True,False
+AC0287-C,K84,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.036,0.003,gamb_colu,gambiae,False,True,True,False
+AC0288-C,K85,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.032,0.003,gamb_colu,gambiae,False,True,True,False
+AC0289-C,K86,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.03,0.003,gamb_colu,gambiae,False,True,True,False
+AC0290-C,K87,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.032,0.002,gamb_colu,gambiae,False,True,True,False
+AC0291-C,K88,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AC0292-C,K89,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.025,0.003,gamb_colu,gambiae,False,True,True,False
+AC0293-C,K90,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.018,0.002,gamb_colu,gambiae,False,True,True,False
+AC0294-C,K91,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.03,0.002,gamb_colu,gambiae,False,True,True,False
+AC0295-C,K92,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AC0296-C,K93,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.029,0.003,gamb_colu,gambiae,False,True,True,False
+AC0297-C,K94,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.026,0.002,gamb_colu,gambiae,False,True,True,False
+AC0298-C,K95,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False
+AC0299-C,K96,AG1000G-UG,Uganda,Kihihi,2012,11,-0.751,29.701,F,0.029,0.002,gamb_colu,gambiae,False,True,True,False

--- a/content/tables/per_sample_location_table_README.txt
+++ b/content/tables/per_sample_location_table_README.txt
@@ -1,0 +1,26 @@
+READ ME 
+per sample location table
+22/07/2020
+
+Rows:
+- one row per AG1000G Phase 3 sample.
+
+Columns:
+- "sample_id" - unique sample code (generated at Sanger).
+- "partner_sample_id" - sample code provided by contributor.
+- "sample_set" - samples are grouped into sets by their submission to the project, each set has a unique code (generated at Sanger).
+- "country" - country where the sample was collected.
+- "site" - site where the sample was collected (provided by contributor).
+- "year" - year that the sample was collected.
+- "month" - month that the sample was collected. Month is represented numerically from 1-12 with 1 being January, 2 February etc.
+- "latitude" - geographic coordinate specifying the north–south position of a sample's collection site.
+- "longitude" - geographic coordinate specifying the west–east position of a sample's collection site.
+- "sex_call" - sample's sex call based on sex-calling pipeline described in methods.
+- "aim_fraction_colu" - proportion of An. coluzzii ancestry informative markers, see methods.
+- "aim_fraction_arab" - proportion of An. arabiensis ancestry informative markers, see methods.
+- "species_gambcolu_arabiensis" - species call. "gambcolu" = An. gambiae or An. coluzzii; "arabiensis" = An. arabiensis; "intermediate" = An. gambiae/coluzzii x An. arabiensis hybrid. See methods.
+- "species_gambiae_coluzzii" - species call. "gambiae" = An. gambiae; "coluzzii" = An. coluzzii; "intermediate" = An. gambiae x An. coluzzii hybrid. See methods.
+- "is_arabiensis" - boolean species call. True = An. arabiensis.
+- "is_gamb_colu" - boolean species call. True = either An. gambiae, An. coluzzii or An. gambiae x An. coluzzii hybrid.
+- "is_gambiae" - boolean species call. True = An. gambiae.
+- "is_coluzzii" - boolean species call. True = An. coluzzii.

--- a/content/tables/site_location_table.csv
+++ b/content/tables/site_location_table.csv
@@ -1,0 +1,44 @@
+country,site,latitude,longitude,counts,female,male,unassigned,arabiensis,arabiensis_x_gambiae,coluzzii,gambiae,coluzzii_x_gambiae
+Angola,Luanda,-8.884,13.302,81,77,4,0,0,0,81,0,0
+Bioko,Bioko,3.7,8.7,10,10,0,0,0,0,0,10,0
+Burkina Faso,Bana,11.233,-4.472,128,81,47,0,1,0,89,37,1
+Burkina Faso,Pala,11.15,-4.235,77,67,10,0,2,0,11,64,0
+Burkina Faso,Souroukoudinga,11.235,-4.535,78,77,1,0,0,0,35,43,0
+Burkina Faso,Monomtenga,12.06,-1.17,13,13,0,0,0,0,0,13,0
+Cameroon,Manda,5.726,10.868,12,12,0,0,0,0,0,12,0
+Cameroon,Gado Badzere,5.747,14.442,97,82,15,0,0,0,0,97,0
+Cameroon,Daiguene,4.777,13.844,96,81,15,0,0,0,0,96,0
+Cameroon,Nkolondom,3.972,11.516,10,10,0,0,0,0,5,5,0
+Cameroon,Mayos,4.341,13.558,110,95,15,0,0,0,0,110,0
+Central African Republic,Bangui,4.367,18.583,73,73,0,0,0,0,18,55,0
+Cote d'Ivoire,Tiassale,5.898,-4.823,80,80,0,0,0,0,80,0,0
+Democratic Republic of Congo,Gbadolite,4.283,21.017,76,44,32,0,0,0,0,76,0
+Gabon,Libreville,0.384,9.455,69,69,0,0,0,0,0,69,0
+Ghana,Takoradi,4.912,-1.774,24,24,0,0,0,0,24,0,0
+Ghana,Twifo Praso,5.609,-1.549,25,25,0,0,0,0,25,0,0
+Ghana,Madina,5.668,-0.219,27,27,0,0,0,0,14,13,0
+Ghana,Koforidua,6.094,-0.261,24,24,0,0,0,0,1,23,0
+Guinea,Koraboh,9.28,-10.03,62,50,12,0,0,0,0,60,2
+Guinea,Koundara,8.48,-9.53,74,62,12,0,0,0,11,63,0
+Guinea-Bissau,Antula,11.891,-15.582,60,60,0,0,0,0,0,15,45
+Guinea-Bissau,Safim,11.957,-15.649,33,33,0,0,0,0,0,6,27
+Kenya,Kilifi,-3.511,39.909,86,75,11,0,13,0,0,28,45
+Malawi,Chikhwawa,-15.933,34.755,41,41,0,0,41,0,0,0,0
+Mali,Toumani Oulena,10.83,-7.81,63,52,11,0,0,0,2,60,1
+Mali,Kela,11.88,-8.45,23,23,0,0,0,0,0,23,0
+Mali,Ouassorola,12.9,-8.16,13,13,0,0,0,0,9,4,0
+Mali,Kababougou,12.89,-8.15,40,32,8,0,0,0,12,28,0
+Mali,Douna,13.21,-5.9,20,20,0,0,1,0,19,0,0
+Mali,Takan,11.47,-8.33,31,25,6,0,0,0,26,5,0
+Mayotte,Mayotte,-12.857,45.137,23,11,12,0,0,0,0,23,0
+Mozambique,Furvela,-23.716,35.299,74,74,0,0,0,0,0,74,0
+Tanzania,Tarime,-1.431,34.199,47,47,0,0,47,0,0,0,0
+Tanzania,Muleba,-1.962,31.651,170,160,10,0,137,0,0,32,1
+Tanzania,Moshi,-3.482,37.308,40,39,1,0,40,0,0,0,0
+Tanzania,Muheza,-4.94,38.948,43,43,0,0,1,0,0,36,6
+The Gambia,Tankular,13.417,-16.033,19,1,0,18,0,0,14,0,5
+The Gambia,Njabakunda,13.55,-15.9,74,74,0,0,0,0,5,58,11
+The Gambia,Wali Kunda,13.567,-14.917,174,174,0,0,0,0,148,2,24
+The Gambia,Sare Samba Sowe,13.583,-15.9,11,1,0,10,0,0,1,9,1
+Uganda,Nagongera,0.77,34.026,194,194,0,0,81,1,0,112,0
+Uganda,Kihihi,-0.751,29.701,96,96,0,0,1,0,0,95,0

--- a/content/tables/site_location_table_README.txt
+++ b/content/tables/site_location_table_README.txt
@@ -1,0 +1,25 @@
+READ ME 
+site location table
+26/10/2020
+
+Notes:
+- Sampling on the island of Mayotte consists of seven sites with low numbers at each, these were combined and latitudes/longitudes averaged due to the small size of the island.
+- For collection data on individual samples see per_sample_location_table.csv.
+
+Rows:
+- one row per AG1000G Phase 3 site where >=10 samples are present.
+
+Columns:
+- "country" - country where the site is situated.
+- "site" - site where samplea were collected (provided by contributor).
+- "latitude" - geographic coordinate specifying the north–south position of a collection site.
+- "longitude" - geographic coordinate specifying the west–east position of a collection site.
+- "counts" - total number of samples collected at this site.
+- "female" - number of female samples.
+- "male" - number of male samples.
+- "unnassigned" - number of samples with unassigned sex.
+- "arabiensis" - number of Anopheles arabiensis.
+- "arabiensis_x_gambiae" - number of Anopheles arabiensis x Anopheles gambiae/coluzzii hybrids.
+- "coluzzii" - number of Anopheles coluzzii.
+- "gambiae" - number of Anopheles gambiae.
+- "coluzzii_x_gambiae" - number of Anopheles coluzzii x Anopheles gambiae hybrids.

--- a/notebooks/sampling_tables.ipynb
+++ b/notebooks/sampling_tables.ipynb
@@ -1,0 +1,466 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/opt/conda/lib/python3.7/site-packages/dask/dataframe/utils.py:14: FutureWarning: pandas.util.testing is deprecated. Use the functions in the public API at pandas.testing instead.\n",
+      "  import pandas.util.testing as tm\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "from pathlib import Path\n",
+    "import yaml\n",
+    "import dask.array as da\n",
+    "from ag3 import release_data\n",
+    "v3_release = release_data()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# supplementary table - sample level\n",
+    "### get meta"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/opt/conda/lib/python3.7/site-packages/pandas/core/computation/expressions.py:68: FutureWarning: elementwise comparison failed; returning scalar instead, but in the future will perform elementwise comparison\n",
+      "  return op(a, b)\n",
+      "/opt/conda/lib/python3.7/site-packages/pandas/core/computation/expressions.py:68: FutureWarning: elementwise comparison failed; returning scalar instead, but in the future will perform elementwise comparison\n",
+      "  return op(a, b)\n"
+     ]
+    }
+   ],
+   "source": [
+    "#samplesets\n",
+    "samplesets = v3_release.all_wild_sample_sets\n",
+    "df_meta = v3_release.load_sample_set_metadata(samplesets, True)\n",
+    "#fixes\n",
+    "df_meta.country = df_meta.country.str.replace(\"Gambia, The\", \"The Gambia\").str.replace(\"Equatorial Guinea\", \"Bioko\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Index(['sample_id', 'partner_sample_id', 'contributor', 'country', 'location',\n",
+       "       'year', 'month', 'latitude', 'longitude', 'sex_call', 'sample_set',\n",
+       "       'aim_fraction_colu', 'aim_fraction_arab', 'species_gambcolu_arabiensis',\n",
+       "       'species_gambiae_coluzzii', 'is_arabiensis', 'is_gamb_colu',\n",
+       "       'is_gambiae', 'is_coluzzii'],\n",
+       "      dtype='object')"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_supp = df_meta.reset_index()\n",
+    "df_supp.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_supp = df_supp[['sample_id', 'partner_sample_id', 'sample_set', 'country', 'location',\n",
+    "       'year', 'month', 'latitude', 'longitude', 'sex_call', 'aim_fraction_colu', 'aim_fraction_arab', 'species_gambcolu_arabiensis',\n",
+    "       'species_gambiae_coluzzii', 'is_arabiensis', 'is_gamb_colu',\n",
+    "       'is_gambiae', 'is_coluzzii']]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_supp.rename(columns={'location':'site'}, inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#round\n",
+    "df_supp = df_supp.round(3)\n",
+    "#export\n",
+    "df_supp.to_csv(\"../content/tables/per_sample_location_table.csv\", index=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# main text table - site >10 level\n",
+    "### fix meta"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(43, 43, 42)"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#consolidate all Mayotte sites into one (so we get a pie chart)\n",
+    "df_meta.loc[(df_meta.country == 'Mayotte'),'latitude'] = df_meta[df_meta.country == 'Mayotte'].latitude.mean()\n",
+    "df_meta.loc[(df_meta.country == 'Mayotte'),'longitude'] = df_meta[df_meta.country == 'Mayotte'].longitude.mean()\n",
+    "#counts by sites\n",
+    "df_site_counts = df_meta.groupby(['latitude', 'longitude', 'country']).size().reset_index(name='counts')\n",
+    "df_site_counts['site'] = range(len(df_site_counts))\n",
+    "#>= 10 sites \n",
+    "df_10 = df_site_counts[df_site_counts.counts >= 10].copy()\n",
+    "len(df_10),len(df_10.latitude.unique()),len(df_10.longitude.unique())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(43, 42)"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#new full meta but only containing >=10 sites (to preserve all species columns)\n",
+    "df_10_meta = df_meta.merge(df_10[['longitude','latitude', 'site']])\n",
+    "len(df_10_meta.latitude.unique()),len(df_10_meta.longitude.unique())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### get crosstabbing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th>species_gambiae_coluzzii</th>\n",
+       "      <th>coluzzii</th>\n",
+       "      <th>gambiae</th>\n",
+       "      <th>gambiae/coluzzii</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>site</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>74</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0</td>\n",
+       "      <td>23</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>81</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0</td>\n",
+       "      <td>36</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>0</td>\n",
+       "      <td>28</td>\n",
+       "      <td>45</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "species_gambiae_coluzzii  coluzzii  gambiae  gambiae/coluzzii\n",
+       "site                                                         \n",
+       "0                                0       74                 0\n",
+       "2                                0       23                 0\n",
+       "3                               81        0                 0\n",
+       "4                                0       36                 6\n",
+       "5                                0       28                45"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "arab_call = pd.crosstab(df_10_meta.site, df_10_meta.species_gambcolu_arabiensis)\n",
+    "colu_call = pd.crosstab(df_10_meta.site, df_10_meta.species_gambiae_coluzzii)\n",
+    "colu_call.rename({\"intermediate\": \"gambiae/coluzzii\"}, axis=1, inplace=True)\n",
+    "colu_call.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th>sex_call</th>\n",
+       "      <th>female</th>\n",
+       "      <th>male</th>\n",
+       "      <th>sex_unknown</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>site</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>74</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>41</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>11</td>\n",
+       "      <td>12</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>77</td>\n",
+       "      <td>4</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>43</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "sex_call  female  male  sex_unknown\n",
+       "site                               \n",
+       "0             74     0            0\n",
+       "1             41     0            0\n",
+       "2             11    12            0\n",
+       "3             77     4            0\n",
+       "4             43     0            0"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sex_call = pd.crosstab(df_10_meta.site, df_10_meta.sex_call)\n",
+    "sex_call.rename({\"F\": \"female\", \"M\": \"male\", \"UKN\": \"sex_unknown\"}, axis=1, inplace=True)\n",
+    "sex_call.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### get building"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#reindex and join\n",
+    "df_10 =  df_10.set_index('site')\n",
+    "df_10_final = df_10.join([arab_call, colu_call, sex_call])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#add locations - must be a better way of doing this using merge maybe?\n",
+    "site = []\n",
+    "for _, row in df_10_final.iterrows():\n",
+    "    all_site = df_meta[(df_meta.latitude == row.latitude) & (df_meta.longitude == row.longitude)].copy()\n",
+    "    if all_site.location.unique()[0] != 'Mtsamboro Forest Reserve':\n",
+    "        site.append(all_site.location.unique()[0])\n",
+    "    else:\n",
+    "        #fix_mayotte\n",
+    "        site.append('Mayotte')\n",
+    "        \n",
+    "df_10_final['region'] = site"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#remove nans, fix types\n",
+    "df_10_final = df_10_final.fillna(value=0).astype({'coluzzii':int, 'gambiae':int, 'gambiae/coluzzii':int})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_10_final = df_10_final[['country', 'region', 'latitude', 'longitude', 'counts', 'female', 'male', \n",
+    "                           'sex_unknown', 'arabiensis', 'intermediate', 'coluzzii', 'gambiae', 'gambiae/coluzzii']]\n",
+    "\n",
+    "#fix names\n",
+    "df_10_final.rename(columns={'region':'site', \"intermediate\":\"arabiensis_x_gambiae\",  'sex_unknown':'unassigned',\n",
+    "                            \"gambiae/coluzzii\": \"coluzzii_x_gambiae\"}, inplace=True)\n",
+    "#sort\n",
+    "df_10_final.sort_values(by=['country'], inplace=True)\n",
+    "#round\n",
+    "df_10_final = df_10_final.round(3)\n",
+    "#export\n",
+    "df_10_final.to_csv(\"../content/tables/site_location_table.csv\", index=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
**supersedes  #20** 

[Q90](https://quire.io/w/malariagen-ag3.0-paper/90)/[Q91](https://quire.io/w/malariagen-ag3.0-paper/91)

Builds sampling table csvs and READMEs.

I have moved the table notebook, csvs and READMEs to this new branch to save trying to fix the conflicts arising from trying to merge the ancient one.

As discussed, long column headers have been reinstated and reference to tables in manuscript removed. 
- Two csvs, one 'per-sample', one 'per-site >=10 samples'. 
- READMEs have been produced for each table to explain rows/columns.